### PR TITLE
API definition.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/ui/node_modules
+
+# production
+/ui/build
+/ui

--- a/README.md
+++ b/README.md
@@ -196,6 +196,24 @@ You can list images in your cluster by running
 
 To add images to the list, simply create `ImageStream` using the above mentioned label
 
+## Spawner API
+
+We are reworking the HTML spawner document to a dynamic spawner page with an API and rendered UI.
+The new API allows gathering data which is shown in the UI.
+The capabilities of the API are:
+  - User ConfigMaps (`GET`, `POST`), It is possible to request the json of the User ConfigMap, and send a body of data to add (or replace). This includes selections, enviroment variables and gpu number.
+  - Sizes (`GET`), Sizes can be requested, either as an array of names (used in the UI) or as a pure json body (using the `pure_json=true` query)
+  - Images (`GET`), Returns an array of images (which have the proper tag). Note: Due to some limitation it is not possible to gather a json with all of the image information
+
+For testing:
+  - To deploy on your cluster use:
+   ```oc apply -f openshift```
+  - Wait for `api-build` to finish (or start a new one) using
+   ```oc get builds```
+  - If `api-deploy` is running you can access the api by using 
+   ```oc get route jh-api-route -o jsonpath='http://{.spec.host}/ui'```
+
+
 # How to Use
 
 ## ConfigMap Method

--- a/app.py
+++ b/app.py
@@ -1,0 +1,58 @@
+import connexion
+import os
+import json
+from jupyterhub_singleuser_profiles.profiles import SingleuserProfiles
+
+_PROFILES = SingleuserProfiles(verify_ssl=False)
+_PROFILES.load_profiles()
+
+def index():
+    with open('./ui/build/index.html', 'r') as f:
+        page = f.read()
+    return page
+
+def handle_local_file(path):
+    with open('./ui/' + path, 'r') as f:
+        page = f.read()
+    return page
+
+def handle_js(path):
+    with open('./ui/build/static/js/' + path) as f:
+        page = f.read()
+    return page
+
+def handle_css(path):
+    with open('./ui/build/static/css/' + path) as f:
+        page = f.read()
+    return page
+
+def get_user_cm(user):
+    cm = _PROFILES.get_user_profile_cm(user)
+    return cm
+
+def update_user_cm(user, body): 
+    _PROFILES.update_user_profile_cm(user, data=body)
+    return _PROFILES.get_user_profile_cm(user)
+
+def get_sizes(pure_json=False):
+    _PROFILES.load_profiles()
+    sizes_json = _PROFILES.get_sizes()
+    if pure_json:
+        return sizes_json
+    response = []
+    for size in sizes_json:
+        response.append(size['name'])
+    return response
+
+def get_images():
+    _PROFILES.load_profiles()
+    image_array = _PROFILES.get_images()
+    return image_array
+
+def get_size_by_name(sizeName):
+    _PROFILES.load_profiles()
+    return _PROFILES.get_size(sizeName)
+
+app = connexion.App(__name__, specification_dir='.', server='tornado', options={'swagger_ui':True})
+app.add_api('swagger.yaml')
+app.run(port=8080)

--- a/jupyterhub_singleuser_profiles/images.py
+++ b/jupyterhub_singleuser_profiles/images.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 import logging
+import json
 
 _LOGGER = logging.getLogger(__name__)
 IMAGE_LABEL = 'opendatahub.io/notebook-image'
@@ -9,14 +10,11 @@ class Images(object):
     def __init__(self, oapi_client, namespace):
         self.oapi_client = oapi_client
         self.namespace = namespace
-
-        
     
     def get_images(self, label=None):
 
         imagestreams = self.oapi_client.resources.get(kind='ImageStream', api_version='image.openshift.io/v1')
         imagestream_list = imagestreams.get(namespace=self.namespace, label_selector=label)
-
         return imagestream_list
 
     def get_images_legacy(self, result, last_image):
@@ -26,19 +24,21 @@ class Images(object):
             if '-notebook' in i.metadata.name:
                 self.append_option(i, result, last_image)
 
-    def append_option(self, image, result, last_image):
+    def append_option(self, image, result, last_image, name_only=False):
         name = image.metadata.name
         if not image.status.tags:
             return
         for tag in image.status.tags:
             selected = ""
             image_tag = "%s:%s" % (name, tag.tag)
-            if image_tag == last_image:
-                selected = "selected=selected"
-            result.append("<option value='%s' %s>%s</option>" % (image_tag, selected, image_tag))
+            if name_only:
+                result.append(image_tag)
+            else:
+                if image_tag == last_image:
+                    selected = "selected=selected"
+                result.append("<option value='%s' %s>%s</option>" % (image_tag, selected, image_tag))
 
-
-    def get_form(self, last_image=None):
+    def get_form(self, last_image=None, name_only=False):
 
         result = []
         imagestream_list = self.get_images(IMAGE_LABEL+'=true')
@@ -47,8 +47,8 @@ class Images(object):
             self.get_images_legacy(result, last_image)
         else:
             for i in imagestream_list.items:
-                self.append_option(i, result, last_image)
-     
+                self.append_option(i, result, last_image, name_only)
+
         response = """
         <h3>JupyterHub Server Image</h3>
         <label for="custom_image">Select desired notebook image</label>
@@ -57,6 +57,9 @@ class Images(object):
         </select>
         \n
         """ % "\n".join(result)
+
+        if name_only:
+            response = result
 
         return response
 

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -40,8 +40,7 @@ class SingleuserProfiles(object):
       kubernetes.client.ApiClient(configuration=configuration)
     )
 
-    self.service = Service(self.namespace, verify_ssl)
-
+    self.service = Service(self.oapi_client, self.namespace)
   @property
   def gpu_mode(self):
     return self._gpu_mode
@@ -95,15 +94,15 @@ class SingleuserProfiles(object):
       else:
         raise
 
-  def update_user_profile_cm(self, username, data={}, key=None, value=None):
+  def update_user_profile_cm(self, username, data={}):
+    
+    user_cm = self.get_user_profile_cm(username)
     cm_name = _USER_CONFIG_MAP_TEMPLATE % escape(username)
     cm_key_name = "profile"
-    cm_data = data
-    if len(data) > 0 and 'env' not in data:
-      cm_data = {'env': data}
-    if key and value:
-      cm_data[key] = value
-    self.write_config_map(cm_name, cm_key_name, cm_data)
+    data = json.loads(data)
+    for key, value in data.items():
+      user_cm[key] = value
+    self.write_config_map(cm_name, cm_key_name, user_cm)
 
   def get_user_profile_cm(self, username):
     return self.read_config_map(_USER_CONFIG_MAP_TEMPLATE % escape(username), "profile")
@@ -120,7 +119,7 @@ class SingleuserProfiles(object):
           self.sizes.extend(config_map_yaml.get("sizes", [self.empty_profile()]))
           self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))
         else:
-          _LOGGER.error("Could not find config map %s" % config_map_name)
+          _LOGGER.error("Could not find config map %s" % cm_name)
       if len(self.profiles) == 0:
         self.profiles.append(self.empty_profile())
       if username:
@@ -198,6 +197,17 @@ class SingleuserProfiles(object):
     s = Sizes(self.sizes)
     return s.get_form(self.get_profile_by_name(_USER_CONFIG_PROFILE_NAME).get('last_selected_size'))
 
+  def get_size(self, size):
+    s = Sizes(self.sizes)
+    return s.get_size(size)
+    
+  def get_sizes(self):
+    return self.sizes
+
+  def get_images(self):
+    i = Images(self.oapi_client, self.namespace)
+    return i.get_form(name_only=True)
+  
   def get_image_list_form(self, username=None):
 
     if not self.profiles:

--- a/jupyterhub_singleuser_profiles/service.py
+++ b/jupyterhub_singleuser_profiles/service.py
@@ -17,21 +17,9 @@ _SERVICE_LABEL="jupyterhub-singluser-service"
 _REFERENCE_CM_NAME = "singleuser-service-ref-%s"
 
 class Service():
-  def __init__(self, namespace, verify_ssl=True):
-    service_account_path = '/var/run/secrets/kubernetes.io/serviceaccount'
-
+  def __init__(self, os_client, namespace):
+    self.os_client = os_client
     self.namespace = namespace
-    self.verify_ssl = verify_ssl
-
-    configuration = client.Configuration()
-    configuration.verify_ssl = self.verify_ssl
-    try:
-      config.load_incluster_config()
-    except Exception as e:
-      config.load_kube_config(client_configuration=configuration)
-
-    k8s_client = client.ApiClient(configuration=configuration)
-    self.os_client = DynamicClient(k8s_client)
 
   def get_service_reference_config_map (self, user):
     cm_name =  _REFERENCE_CM_NAME %(escape(user))

--- a/openshift/api-build.yaml
+++ b/openshift/api-build.yaml
@@ -1,0 +1,30 @@
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: api-build
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'api-image:latest'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        namespace: openshift
+        name: 'python:3.6'
+  postCommit: {}
+  source:
+    type: Git
+    git:
+      uri: 'https://github.com/mroman-redhat/jupyterhub-singleuser-profiles.git'
+      ref: Issue-30
+  triggers:
+    - type: ImageChange
+    - type: ConfigChange
+  runPolicy: Serial

--- a/openshift/api-deploy.yaml
+++ b/openshift/api-deploy.yaml
@@ -1,0 +1,44 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: api-deploy
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: api-app
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: api-app
+    spec:
+      serviceAccountName: api-sa
+      containers:
+        - name: api-image
+          image: 'api-image:latest'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Always
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/openshift/api-edit-rb.yaml
+++ b/openshift/api-edit-rb.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: api-edit-rb
+subjects:
+  - kind: ServiceAccount
+    name: api-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: api-edit

--- a/openshift/api-edit.yaml
+++ b/openshift/api-edit.yaml
@@ -1,0 +1,24 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: api-edit
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - imagestreams
+  - verbs:
+      - list
+    apiGroups:
+      - 'image.openshift.io'
+    resources:
+      - imagestreams

--- a/openshift/api-image.yaml
+++ b/openshift/api-image.yaml
@@ -1,0 +1,14 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: api-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      generation: 1
+      importPolicy: {}
+      referencePolicy:
+        type: Source

--- a/openshift/api-sa.yaml
+++ b/openshift/api-sa.yaml
@@ -1,0 +1,4 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: api-sa

--- a/openshift/api-service.yaml
+++ b/openshift/api-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: api-service
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: api-app
+  sessionAffinity: None
+status:
+  loadBalancer: {}

--- a/openshift/example-configmap.yaml
+++ b/openshift/example-configmap.yaml
@@ -1,0 +1,116 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: jupyter-singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+    profiles:
+      - name: globals
+        env:
+        - name: THIS_IS_GLOBAL
+          value: "This will appear in all singleuser pods"
+        - name: MYAPP_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: SECRET_TOKEN
+              name: testing-secret-token
+        - name: MY_CONFIGMAP_VALUE
+          valueFrom:
+            configMapKeyRef:
+              name: myconfigmap
+              key: mykey
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      - name: Special Nodes
+        users:
+        - acorvin
+        # Set OpenShift node tolerations for a notebook pod. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more information.
+        node_tolerations:
+          - key: some_node_label
+            operator: Equal
+            value: label_target_value
+            effect: NoSchedule
+        # Set OpenShift node affinity for a notebook pod. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ for more information.
+        node_affinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: some_node_label
+                  operator: In
+                  values:
+                  - label_target_value_1
+                  - label_target_value_2
+      - name: Thoth Notebooks
+        images:
+        - 's2i-thoth-notebook:3.6'
+        users:
+        - vpavlin
+        - fpokorny
+        env:
+        - name: THOTH_DEPLOYMENT_NAME
+          value: thoth-test-core
+        - name: THOTH_CEPH_BUCKET
+          value: DH-DEV-DATA
+        - name: THOTH_CEPH_BUCKET_PREFIX
+          value: data/thoth
+        - name: THOTH_JANUSGRAPH_PORT
+          value: '80'
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "1"
+      - name: Spark Notebook
+        images:
+        - 's2i-spark-notebook:3.6'
+        services:
+          spark:
+            resources:
+            - name: spark-cluster-template
+              path: sparkClusterTemplate
+            configuration:
+              worker_instances: 1
+              worker_memory_limit: 4Gi
+              master_memory_limit: 1Gi
+            labels:
+              opendatahub.io/component: jupyterhub
+            return:
+              SPARK_CLUSTER: 'metadata.name'
+          airflow:
+            resources:
+            - name: jupyter-services-template
+              path: airflowCluster
+            - name: jupyter-services-template
+              path: airflowBase
+    sizes:
+      - name: Small
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "1"
+          limits:
+            memory: "2Gi"
+            cpu: "2"
+      - name: Medium
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "2"
+          limits:
+            memory: "4Gi"
+            cpu: "4"
+      - name: Large
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "4"
+          limits:
+            memory: "8Gi"
+            cpu: "8"

--- a/openshift/jh-api-route.yaml
+++ b/openshift/jh-api-route.yaml
@@ -1,0 +1,12 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: jh-api-route
+spec:
+  to:
+    kind: Service
+    name: api-service
+    weight: 100
+  port:
+    targetPort: 8080
+  wildcardPolicy: None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
-openshift==0.8.6
+openshift
 PyYAML
 requests
 jsonpath-rw
+connexion[swagger-ui]
+connexion
+gevent
 jinja2
 escapism
+tornado
+npm

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,0 +1,176 @@
+openapi: 3.0.0
+info:
+  title: JupyterHub API
+  description: API for the Spawner UI of JupyterHub
+  version: 0.1.0
+
+paths:
+  /:
+    get:
+      operationId: app.index
+      responses:
+        '200':
+          description: OK
+          content:
+            text/html:
+              schema:
+                type: string
+  
+  /{path}:
+    get:
+      operationId: app.handle_local_file
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+  
+  /static/js/{path}:
+    get:
+      operationId: app.handle_js
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/javascript:
+              schema:
+                type: string
+  
+  /static/css/{path}:
+    get:
+      operationId: app.handle_css
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/css:
+              schema:
+                type: string
+
+  /api/user/{user}/configmap:
+    get:
+      operationId: app.get_user_cm
+      summary: Get a ConfigMap
+      parameters:
+        - name: user
+          in: path
+          required: true
+          description: User for which to get configmap
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/configmap'
+        '404':
+          description: ConfigMap not found
+    post:
+      operationId: app.update_user_cm
+      summary: Updates user cm with json data and returns it as response
+      parameters:
+        - name: user
+          in: path
+          required: true
+          description:  User for which to get configmap
+          schema:
+            type: string 
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/configmap'
+
+  /api/images:
+    get:
+      operationId: app.get_images
+      summary: Get an array of strings of image names (not capable of returning pure json)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      type: string
+                  - type: string
+
+  /api/sizes:
+    get:
+      operationId: app.get_sizes
+      summary: Get an array strings of size names or a pure json with all parameters
+      parameters:
+        - name: pure_json
+          in: query
+          required: false
+          description: Returns a full json if true
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      type: string
+                  - type: string
+  
+  /api/size/{sizeName}:
+    get:
+      operationId: app.get_size_by_name
+      summary: Get a single size by name
+      parameters:
+        - name: sizeName
+          in: path
+          required: true
+          description: Name of the size
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: Size not found
+
+components:
+  schemas:
+    configmap:
+      type: string


### PR DESCRIPTION
Added a swagger API definition for UI purposes.

A couple of notes:
- Username will be set in the UI not the API
- Local/static file requests are handled primitively, however I assumed its not necessary to rework, since the API will only ever receive requests for 3 known files.
- the `openshift` folder contains files needed to run the api on the cluster
- The API has the following capabilities:
   - Get/Update a user ConfigMap (GPU, and EnvVar reading is included in this, will split if necessary)
   - Get Sizes (Both full json readout of just the names), Also get a single size
   - Get Images (Names only)

Information for testing is in the API section of Readme