### PR TITLE
Set the MEM_LIMIT env var to real memory limit

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -304,6 +304,19 @@ class SingleuserProfiles(object):
         return mountPath
       return os.path.join(default_mount_path, mountPath)
     return os.path.join(default_mount_path, volume_name)
+
+  @classmethod
+  def get_mem_limit(self, memory_limit):
+    if 'Ti' in memory_limit:
+      memory_limit = int(memory_limit[:-2]) * 1024 * 1024 * 1024 * 1024
+    elif 'Gi' in memory_limit:
+      memory_limit = int(memory_limit[:-2]) * 1024 * 1024 * 1024
+    elif 'Mi' in memory_limit:
+      memory_limit = int(memory_limit[:-2]) * 1024 * 1024
+    elif 'Ki' in memory_limit:
+      memory_limit = int(memory_limit[:-2]) * 1024
+
+    return str(memory_limit)
     
 
   @classmethod
@@ -353,6 +366,9 @@ class SingleuserProfiles(object):
 
     if resource_var:
       pod.spec.containers[0].resources = resource_var
+      mem_limit = resource_var.limits.get('memory', '')
+      if mem_limit:
+        pod.spec.containers[0].env.append(V1EnvVar(name='MEM_LIMIT', value=self.get_mem_limit(mem_limit)))
       
     if profile.get('node_tolerations'):
         pod.spec.tolerations = profile.get('node_tolerations')


### PR DESCRIPTION
JupyterLab is using `MEM_LIMIT` env var to visualize memory consumption and the limit. We had MEM_LIMIT set to a hardcoded value. This PR fixes that and sets MEM_LIMIT to an actual value