### PR TITLE
Deep copy the default CM to prevent pointer issues

### DIFF
--- a/jupyterhub_singleuser_profiles/user.py
+++ b/jupyterhub_singleuser_profiles/user.py
@@ -43,7 +43,7 @@ class User(object):
   def get_presets(self, username):
     presets = self.openshift.read_config_map(self._USER_CONFIG_MAP_TEMPLATE % escape(username), "profile")
     if presets == {}:
-      presets = self._DEFAULT_USER_PRESETS
+      presets = copy.deepcopy(self._DEFAULT_USER_PRESETS)
 
     presets = self.fix_if_legacy(username, presets)
 


### PR DESCRIPTION
The original code had an issue that as user profile got loaded, the default CM got updated because the profile had a pointer reference to the variable holding default. This bond needed to be cut to make sure we always start from scratch