### PR TITLE
Forced https requests

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -52,6 +52,15 @@ def authenticated(f):
 
     return decorated
 
+@app.before_request
+def before_request():
+    if request.is_secure:
+        return
+
+    url = request.url.replace("http://", "https://", 1)
+    code = 301
+    return redirect(url, code=code)
+
 @authenticated
 def whoami(user):
     return Response(


### PR DESCRIPTION
In case this change does not solve the http call problem, it is also possible to define `schemes` in the Swagger YAML file: https://swagger.io/docs/specification/2-0/api-host-and-base-path/