### PR TITLE
Remove resources from empty_profile to prevent overriding

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -164,18 +164,7 @@ class SingleuserProfiles(object):
       "env": {},
       "node_tolerations": [],
       "node_affinity": {},
-      "resources": {
-        "requests": {
-          "memory": None,
-          "cpu": None
-        },
-        "limits": {
-          "memory": None,
-          "cpu": None
-        },
-        "mem_limit": None,
-        "cpu_limit": None
-      },
+      "resources": {},
       "services": {}
     }
 


### PR DESCRIPTION
The defaults in `empty_profile` caused the `Default` size to be set to all 0 for all attributes