### PR TITLE
Add default empty list before loop in tag_exists

### DIFF
--- a/jupyterhub_singleuser_profiles/images.py
+++ b/jupyterhub_singleuser_profiles/images.py
@@ -49,7 +49,11 @@ class Images(object):
         return image_list[0].name if len(image_list) else None
 
     def tag_exists(self, tag_name, imagestream):
-        for tag in imagestream.status.tags:
+        """
+        Check that tag_name exists in .status.tags. This handles situations where the tag exists but .spec.tags[] does not.
+        """
+        imagestream_status_tags = imagestream.status.get('tags', [])
+        for tag in imagestream_status_tags:
             if tag_name == tag.tag:
                 return True
 


### PR DESCRIPTION
jsp/image.py Use default empty list '[]' when imagestream `.status.tags` does not exist

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>