### PR TITLE
Cleanup ugly redundant code for using default image display name

### DIFF
--- a/jupyterhub_singleuser_profiles/images.py
+++ b/jupyterhub_singleuser_profiles/images.py
@@ -96,7 +96,7 @@ class Images(object):
 
                 result.append(ImageInfo(description=annotations.get(DESCRIPTION_ANNOTATION),
                                     url=annotations.get(URL_ANNOTATION),
-                                    display_name=annotations.get(DISPLAY_NAME_ANNOTATION) or imagestream_name,
+                                    display_name=annotations.get(DISPLAY_NAME_ANNOTATION, imagestream_name),
                                     name=imagestream_name,
                                     content=ImageTagInfo(
                                         software=json.loads(tag_annotations.get(SOFTWARE_ANNOTATION, "[]")),\


### PR DESCRIPTION
Fix redundant code that uses the `or` operator instead of setting default value as part of the DICTIONARY.get() method.  I added this code in #148 and just want to clean it up

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>