### PR TITLE
Add safeguards around imagestreams with no tags

### DIFF
--- a/jupyterhub_singleuser_profiles/images.py
+++ b/jupyterhub_singleuser_profiles/images.py
@@ -90,6 +90,10 @@ class Images(object):
             if i.spec.tags:
                 imagestream_tags = i.spec.tags
 
+            if len(imagestream_tags) == 0:
+                _LOGGER.warning(f'{i.metadata.name} does not have any tags')
+                continue
+
             for tag in imagestream_tags:
                 if not self.tag_exists(tag.name, i):
                     continue
@@ -112,7 +116,7 @@ class Images(object):
 
             result.append(ImageInfo(description=annotations.get(DESCRIPTION_ANNOTATION),
                                 url=annotations.get(URL_ANNOTATION),
-                                display_name=annotations.get(DISPLAY_NAME_ANNOTATION) or i.metadata.name,
+                                display_name=annotations.get(DISPLAY_NAME_ANNOTATION) or imagestream_name,
                                 name=i.metadata.name,
                                 tags=tag_list,
                                 default=bool(strtobool(annotations.get(DEFAULT_IMAGE_ANNOTATION, "False"))),

--- a/jupyterhub_singleuser_profiles/images.py
+++ b/jupyterhub_singleuser_profiles/images.py
@@ -30,7 +30,7 @@ class ImageTagInfo(BaseModel):
     name: str
     content: TagContent
     recommended: bool
-    
+    build_status: str
 
 class ImageInfo(BaseModel):
     name: str
@@ -40,7 +40,6 @@ class ImageInfo(BaseModel):
     display_name: Optional[str]
     default: bool = False
     order: int = 100
-    build_status: str
     
 class Images(object):
     def __init__(self, openshift, namespace):
@@ -107,17 +106,17 @@ class Images(object):
                                                 dependencies=json.loads(tag_annotations.get(DEPENDENCIES_ANNOTATION, "[]"))
                                             ),
                                             name=tag.name,
-                                            recommended=tag_annotations.get(RECOMMENDED_ANNOTATION, False)
+                                            recommended=tag_annotations.get(RECOMMENDED_ANNOTATION, False),
+                                            build_status=self.get_image_build_status(imagestream_name)
                 ))
 
             result.append(ImageInfo(description=annotations.get(DESCRIPTION_ANNOTATION),
                                 url=annotations.get(URL_ANNOTATION),
-                                display_name=annotations.get(DISPLAY_NAME_ANNOTATION) or imagestream_name,
+                                display_name=annotations.get(DISPLAY_NAME_ANNOTATION) or i.metadata.name,
                                 name=i.metadata.name,
                                 tags=tag_list,
                                 default=bool(strtobool(annotations.get(DEFAULT_IMAGE_ANNOTATION, "False"))),
                                 order=int(annotations.get(IMAGE_ORDER_ANNOTATION, 100)),
-                                build_status=self.get_image_build_status(imagestream_name)
                                 ))
 
         result.sort(key=self.check_place)


### PR DESCRIPTION
In situations where the imagestream has no available tags the value for
imagestream_name never gets set, resulting in the build_status
assignment failing. This change will result in "latest" being used as
the default tag.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>