### PR TITLE
Handle multiple version of notebooks

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/App/App.scss
+++ b/jupyterhub_singleuser_profiles/ui/src/App/App.scss
@@ -19,8 +19,7 @@
     border-top: 1px solid var(--pf-global--BorderColor--100);
     padding-top: var(--pf-global--spacer--lg);
     text-align: left;
-    width: 50%;
-    min-width: 622px;
+    max-width: 768px;
 
     &:first-of-type {
       margin-top: 0;

--- a/jupyterhub_singleuser_profiles/ui/src/EnvVarForm/EnvVariablesVariable.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/EnvVarForm/EnvVariablesVariable.tsx
@@ -58,10 +58,7 @@ const EnvVariablesVariable: React.FC<EnvVariablesVariableProps> = ({
           onBlur={onBlur}
         />
       </FormGroup>
-      <FormGroup
-        fieldId={`${variable.name}-value`}
-        label="Variable value"
-      >
+      <FormGroup fieldId={`${variable.name}-value`} label="Variable value">
         <div className="jsp-spawner__env-var-form__var-row__vars__value">
           <TextInput
             id={`${variable.name}-value`}

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.scss
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.scss
@@ -1,9 +1,16 @@
 .jsp-spawner__image-options {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  column-gap: var(--pf-global--spacer--4xl);
-  row-gap: var(--pf-global--spacer--md);
-  margin-top: var(--pf-global--spacer--md);
+  @media (min-width: 768px) {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+  }
+
+  &__group {
+    min-width: 350px;
+  }
+  &__image {
+    margin-top: var(--pf-global--spacer--md);
+  }
   &__option {
     .pf-c-radio__label {
       white-space: nowrap;
@@ -15,6 +22,9 @@
     }
     > svg {
       margin-left: var(--pf-global--spacer--xs);
+    }
+    .pf-c-label {
+      margin-top: -3px;
     }
   }
   &__tags {
@@ -39,7 +49,7 @@
   &__packages-popover {
     min-width: initial !important;
     .pf-c-popover__content {
-      max-width: 210px;
+      max-width: 275px;
       overflow-x: hidden;
       > .pf-c-button {
         padding-left: 0;
@@ -50,7 +60,12 @@
       padding-right: var(--pf-global--spacer--lg) !important;
     }
     &__title {
-      display: block;
+      display: inline-block;
+      font-weight: var(--pf-global--FontWeight--bold);
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
+    &__package-title {
+      display: inline-block;
       font-weight: var(--pf-global--FontWeight--bold);
     }
     &__package {

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.scss
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.scss
@@ -10,8 +10,30 @@
     }
   }
   &__title {
+    &-version {
+      margin-left: var(--pf-global--spacer--xs);
+    }
     > svg {
       margin-left: var(--pf-global--spacer--xs);
+    }
+  }
+  &__tags {
+    margin: 0 var(--pf-global--spacer--md);
+    .pf-c-button.pf-m-tertiary {
+      --pf-c-button--after--BorderColor: transparent;
+      padding-left: 2px;
+      > svg {
+        margin-right: var(--pf-global--spacer--xs);
+      }
+    }
+  }
+  &__tag-versions {
+    margin: 0 var(--pf-global--spacer--md);
+    .jsp-spawner__image-options__option:not(:last-of-type) {
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
+    .pf-c-label {
+      margin-left: var(--pf-global--spacer--sm);
     }
   }
   &__packages-popover {

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { Radio } from '@patternfly/react-core';
 import { APIGet, APIPost } from '../utils/APICalls';
 import { CM_PATH, DEFAULT_IMAGE_PATH, IMAGE_PATH } from '../utils/const';
-import { ImageType, UserConfigMapType, UiConfigType, ImageTagType } from '../utils/types';
-import ImageVersions from './ImageVersions';
-import { getDescriptionForTag } from './imageUtils';
-import ImageTagPopover from './ImageTagPopover';
+import { ImageType, UserConfigMapType, UiConfigType } from '../utils/types';
+import { getDefaultTag } from './imageUtils';
+import ImageSelector from './ImageSelector';
 
 import './ImageForm.scss';
 
@@ -78,94 +76,48 @@ const ImageForm: React.FC<ImageFormProps> = () => {
     };
   }, [selectedImageTag, imageList]);
 
-  const getDefaultTag = (image: ImageType): ImageTagType => {
-    if (image?.tags.length > 1) {
-      const defaultTag = image.tags.find((tag) => tag.recommended);
-      if (defaultTag) {
-        return defaultTag;
-      }
-    }
-    return image.tags[0];
-  };
-
   const handleSelection = (image: ImageType, tag: string, checked: boolean) => {
     if (checked) {
-      if (image.name !== selectedImageTag?.image) {
-        setSelectedImageTag({ image: image.name, tag: getDefaultTag(image).name });
-      } else {
-        setSelectedImageTag({ image: image.name, tag });
-      }
-      postChange(`${image}:${tag}`);
+      setSelectedImageTag({ image: image.name, tag });
+      postChange(`${image.name}:${tag}`);
     }
   };
-
-  const getTagForImage = (image: ImageType): ImageTagType => {
-    let tag;
-    if (image.tags.length > 1) {
-      if (image.name === selectedImageTag?.image && selectedImageTag?.tag) {
-        tag = image.tags.find((tag) => tag.name === selectedImageTag?.tag);
-      } else {
-        tag = getDefaultTag(image);
-      }
-    }
-    return tag || image.tags[0];
-  };
-
-  const getImageTagVersion = (image: ImageType): string => {
-    if (image?.tags.length > 1) {
-      const defaultTag = getDefaultTag(image);
-      if (image.name === selectedImageTag?.image && selectedImageTag?.tag) {
-        return `${selectedImageTag?.tag} ${
-          selectedImageTag?.tag === defaultTag?.name ? ' (default)' : ''
-        }`;
-      }
-      return defaultTag?.name ?? image.tags[0].name;
-    }
-    return '';
-  };
-
-  const getImagePopover = (image: ImageType) => {
-    const tag = getTagForImage(image);
-    if (!tag?.content?.dependencies?.length) {
-      return null;
-    }
-    return <ImageTagPopover tag={tag} />;
-  };
-
-  const selectOptions =
-    imageList?.map((image) => (
-      <div key={image.name}>
-        <Radio
-          id={image.name}
-          name={image.display_name}
-          className="jsp-spawner__image-options__option"
-          label={
-            <span className="jsp-spawner__image-options__title">
-              {image.display_name}
-              {image.tags.length > 1 ? (
-                <span className="jsp-spawner__image-options__title-version">
-                  {getImageTagVersion(image)}
-                </span>
-              ) : null}
-              {getImagePopover(image)}
-            </span>
-          }
-          description={getDescriptionForTag(getTagForImage(image))}
-          isChecked={image.name === selectedImageTag?.image}
-          onChange={(checked: boolean) => handleSelection(image, '', checked)}
-        />
-        <ImageVersions
-          image={image}
-          selectedTag={image.name === selectedImageTag?.image ? selectedImageTag.tag : ''}
-          onSelect={(tagName, checked) => handleSelection(image, tagName, checked)}
-        />
-      </div>
-    )) ?? [];
 
   return (
     <div className="jsp-spawner__option-section">
       <div className="jsp-spawner__option-section__title">Notebook image</div>
-      <div className="jsp-spawner__image-options">{selectOptions}</div>
+      <div className="jsp-spawner__image-options">
+        <div className="jsp-spawner__image-options__group">
+          {imageList
+            ? imageList?.map((image, index) =>
+                index < Math.ceil(imageList.length / 2) ? (
+                  <ImageSelector
+                    key={image.name}
+                    image={image}
+                    selectedImage={selectedImageTag?.image}
+                    selectedTag={selectedImageTag?.tag}
+                    handleSelection={handleSelection}
+                  />
+                ) : null,
+              )
+            : null}
+        </div>
+        <div className="jsp-spawner__image-options__group">
+          {imageList
+            ? imageList?.map((image, index) =>
+                index >= Math.ceil(imageList.length / 2) ? (
+                  <ImageSelector
+                    key={image.name}
+                    image={image}
+                    selectedImage={selectedImageTag?.image}
+                    selectedTag={selectedImageTag?.tag}
+                    handleSelection={handleSelection}
+                  />
+                ) : null,
+              )
+            : null}
+        </div>
+      </div>
     </div>
   );
 };

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { Popover, Radio } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Radio } from '@patternfly/react-core';
 import { APIGet, APIPost } from '../utils/APICalls';
 import { CM_PATH, DEFAULT_IMAGE_PATH, IMAGE_PATH } from '../utils/const';
-import { ImageType, ImageSoftwareType, UserConfigMapType, UiConfigType } from '../utils/types';
+import { ImageType, UserConfigMapType, UiConfigType, ImageTagType } from '../utils/types';
+import ImageVersions from './ImageVersions';
+import { getDescriptionForTag } from './imageUtils';
+import ImageTagPopover from './ImageTagPopover';
 
 import './ImageForm.scss';
 
@@ -11,8 +13,16 @@ type ImageFormProps = {
   uiConfig: UiConfigType;
 };
 
-const ImageForm: React.FC<ImageFormProps> = ({ uiConfig }) => {
-  const [selectedValue, setSelectedValue] = React.useState<string>();
+const getValuesFromImageName = (imageName: string): { image: string; tag: string } => {
+  const index = imageName?.indexOf(':');
+  return {
+    image: index > 0 ? imageName.slice(0, index) : imageName,
+    tag: index > 0 ? imageName.slice(index + 1) : '',
+  };
+};
+
+const ImageForm: React.FC<ImageFormProps> = () => {
+  const [selectedImageTag, setSelectedImageTag] = React.useState<{ image: string; tag: string }>();
   const [imageList, setImageList] = React.useState<ImageType[]>();
 
   const postChange = (text) => {
@@ -24,12 +34,12 @@ const ImageForm: React.FC<ImageFormProps> = ({ uiConfig }) => {
     let cancelled = false;
     APIGet(CM_PATH).then((data: UserConfigMapType) => {
       if (!cancelled) {
-        setSelectedValue(data['last_selected_image'] || '');
+        setSelectedImageTag(getValuesFromImageName(data['last_selected_image']));
       }
     });
     APIGet(IMAGE_PATH).then((data: ImageType[]) => {
       if (!cancelled) {
-        setImageList(data);
+        setImageList(data.sort((a, b) => a.order - b.order));
       }
     });
     return () => {
@@ -40,91 +50,116 @@ const ImageForm: React.FC<ImageFormProps> = ({ uiConfig }) => {
   React.useEffect(() => {
     let cancelled = false;
 
-    if (!imageList || selectedValue === undefined) {
+    // Wait until we have both
+    if (!imageList || selectedImageTag === undefined) {
       return;
     }
 
-    if (selectedValue && imageList.find((image) => image.name === selectedValue)) {
+    // If the previous are valid, we are good
+    const currentImage = imageList.find((image) => image.name === selectedImageTag.image);
+    const currentTag = currentImage?.tags.find((tag) => tag.name === selectedImageTag.tag);
+    if (currentImage && currentTag) {
       return;
     }
 
+    // Fetch the defaults and use them
     APIGet(DEFAULT_IMAGE_PATH).then((data: string) => {
-      if (!cancelled) {
-        setSelectedValue(data);
-        postChange(data);
+      if (!cancelled && data) {
+        const values = getValuesFromImageName(data);
+        if (values.image && values.tag) {
+          setSelectedImageTag(values);
+          postChange(data);
+        }
       }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [selectedValue, imageList]);
+  }, [selectedImageTag, imageList]);
 
-  const handleSelection = (image: string, checked: boolean) => {
+  const getDefaultTag = (image: ImageType): ImageTagType => {
+    if (image?.tags.length > 1) {
+      const defaultTag = image.tags.find((tag) => tag.recommended);
+      if (defaultTag) {
+        return defaultTag;
+      }
+    }
+    return image.tags[0];
+  };
+
+  const handleSelection = (image: ImageType, tag: string, checked: boolean) => {
     if (checked) {
-      setSelectedValue(image);
-      postChange(image);
+      if (image.name !== selectedImageTag?.image) {
+        setSelectedImageTag({ image: image.name, tag: getDefaultTag(image).name });
+      } else {
+        setSelectedImageTag({ image: image.name, tag });
+      }
+      postChange(`${image}:${tag}`);
     }
   };
 
-  const getNameVersionString = (software: ImageSoftwareType): string => {
-    const versionString = software?.version ? ` ${software?.version}` : '';
-    return `${software.name}${versionString}`;
+  const getTagForImage = (image: ImageType): ImageTagType => {
+    let tag;
+    if (image.tags.length > 1) {
+      if (image.name === selectedImageTag?.image && selectedImageTag?.tag) {
+        tag = image.tags.find((tag) => tag.name === selectedImageTag?.tag);
+      } else {
+        tag = getDefaultTag(image);
+      }
+    }
+    return tag || image.tags[0];
   };
 
-  const getDescriptionForImage = (image: ImageType): string => {
-    const softwareDescriptions = image.content.software.map((software) =>
-      getNameVersionString(software),
-    );
-    return softwareDescriptions.join(', ');
+  const getImageTagVersion = (image: ImageType): string => {
+    if (image?.tags.length > 1) {
+      const defaultTag = getDefaultTag(image);
+      if (image.name === selectedImageTag?.image && selectedImageTag?.tag) {
+        return `${selectedImageTag?.tag} ${
+          selectedImageTag?.tag === defaultTag?.name ? ' (default)' : ''
+        }`;
+      }
+      return defaultTag?.name ?? image.tags[0].name;
+    }
+    return '';
   };
 
-  const getImagePopover = (image) => {
-    if (!image.content?.dependencies?.length) {
+  const getImagePopover = (image: ImageType) => {
+    const tag = getTagForImage(image);
+    if (!tag?.content?.dependencies?.length) {
       return null;
     }
-    return (
-      <Popover
-        className="jsp-spawner__image-options__packages-popover"
-        showClose
-        bodyContent={
-          <>
-            <span className="jsp-spawner__image-options__packages-popover__title">
-              Packages included:
-            </span>
-            {image.content.dependencies.map((dependency) => (
-              <span
-                key={dependency.name}
-                className="jsp-spawner__image-options__packages-popover__package"
-              >
-                {getNameVersionString(dependency)}
-              </span>
-            ))}
-          </>
-        }
-      >
-        <OutlinedQuestionCircleIcon />
-      </Popover>
-    );
+    return <ImageTagPopover tag={tag} />;
   };
 
   const selectOptions =
     imageList?.map((image) => (
-      <Radio
-        key={image.name}
-        id={image.name}
-        name={image.display_name}
-        className="jsp-spawner__image-options__option"
-        label={
-          <span className="jsp-spawner__image-options__title">
-            {image.display_name}
-            {getImagePopover(image)}
-          </span>
-        }
-        description={getDescriptionForImage(image)}
-        isChecked={image.name === selectedValue}
-        onChange={(checked: boolean) => handleSelection(image.name, checked)}
-      />
+      <div key={image.name}>
+        <Radio
+          id={image.name}
+          name={image.display_name}
+          className="jsp-spawner__image-options__option"
+          label={
+            <span className="jsp-spawner__image-options__title">
+              {image.display_name}
+              {image.tags.length > 1 ? (
+                <span className="jsp-spawner__image-options__title-version">
+                  {getImageTagVersion(image)}
+                </span>
+              ) : null}
+              {getImagePopover(image)}
+            </span>
+          }
+          description={getDescriptionForTag(getTagForImage(image))}
+          isChecked={image.name === selectedImageTag?.image}
+          onChange={(checked: boolean) => handleSelection(image, '', checked)}
+        />
+        <ImageVersions
+          image={image}
+          selectedTag={image.name === selectedImageTag?.image ? selectedImageTag.tag : ''}
+          onSelect={(tagName, checked) => handleSelection(image, tagName, checked)}
+        />
+      </div>
     )) ?? [];
 
   return (

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { Radio } from '@patternfly/react-core';
+import { ImageType } from '../utils/types';
+import { getDescriptionForTag, getImageTagVersion, getTagForImage } from './imageUtils';
+import ImageTagPopover from './ImageTagPopover';
+import ImageVersions from './ImageVersions';
+
+type ImageSelectorProps = {
+  image: ImageType;
+  selectedImage?: string;
+  selectedTag?: string;
+  handleSelection: (image: ImageType, tag: string, checked: boolean) => void;
+};
+
+const ImageSelector: React.FC<ImageSelectorProps> = ({
+  image,
+  selectedImage,
+  selectedTag,
+  handleSelection,
+}) => {
+  const currentTag = getTagForImage(image, selectedImage, selectedTag);
+
+  const getImagePopover = (image: ImageType) => {
+    if (!image.description && !currentTag?.content?.dependencies?.length) {
+      return null;
+    }
+    return <ImageTagPopover tag={currentTag} description={image.description || undefined} />;
+  };
+
+  return (
+    <div className="jsp-spawner__image-options__image">
+      <Radio
+        id={image.name}
+        name={image.display_name}
+        className="jsp-spawner__image-options__option"
+        label={
+          <span className="jsp-spawner__image-options__title">
+            {image.display_name}
+            {image.tags.length > 1 ? (
+              <span className="jsp-spawner__image-options__title-version">
+                {getImageTagVersion(image, selectedImage, selectedTag)}
+              </span>
+            ) : null}
+            {getImagePopover(image)}
+          </span>
+        }
+        description={getDescriptionForTag(currentTag)}
+        isChecked={image.name === selectedImage}
+        onChange={(checked: boolean) => handleSelection(image, currentTag.name, checked)}
+      />
+      <ImageVersions
+        image={image}
+        selectedTag={image.name === selectedImage ? selectedTag : ''}
+        onSelect={(tagName, checked) => handleSelection(image, tagName, checked)}
+      />
+    </div>
+  );
+};
+
+export default ImageSelector;

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
@@ -6,30 +6,52 @@ import { getNameVersionString } from './imageUtils';
 
 type ImageTagPopoverProps = {
   tag: ImageTagType;
+  description?: string;
 };
 
-const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag }) => (
-  <Popover
-    className="jsp-spawner__image-options__packages-popover"
-    showClose
-    bodyContent={
-      <>
-        <span className="jsp-spawner__image-options__packages-popover__title">
-          Packages included:
-        </span>
-        {tag.content.dependencies.map((dependency) => (
-          <span
-            key={dependency.name}
-            className="jsp-spawner__image-options__packages-popover__package"
-          >
-            {getNameVersionString(dependency)}
-          </span>
-        ))}
-      </>
-    }
-  >
-    <OutlinedQuestionCircleIcon />
-  </Popover>
-);
+const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag, description }) => {
+  const [isVisible, setIsVisible] = React.useState(false);
+  return (
+    <Popover
+      className="jsp-spawner__image-options__packages-popover"
+      isVisible={isVisible}
+      shouldOpen={(show, event) => {
+        event?.preventDefault();
+        setIsVisible(true);
+      }}
+      shouldClose={(tip, show, event) => {
+        event?.preventDefault();
+        setIsVisible(false);
+      }}
+      showClose
+      bodyContent={
+        <>
+          {description ? (
+            <span className="jsp-spawner__image-options__packages-popover__title">
+              {description}
+            </span>
+          ) : null}
+          {tag.content?.dependencies?.length > 0 ? (
+            <>
+              <span className="jsp-spawner__image-options__packages-popover__package-title">
+                Packages included:
+              </span>
+              {tag.content.dependencies.map((dependency) => (
+                <span
+                  key={dependency.name}
+                  className="jsp-spawner__image-options__packages-popover__package"
+                >
+                  {getNameVersionString(dependency)}
+                </span>
+              ))}
+            </>
+          ) : null}
+        </>
+      }
+    >
+      <OutlinedQuestionCircleIcon />
+    </Popover>
+  );
+};
 
 export default ImageTagPopover;

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { ImageTagType } from '../utils/types';
+import { getNameVersionString } from './imageUtils';
+
+type ImageTagPopoverProps = {
+  tag: ImageTagType;
+};
+
+const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag }) => (
+  <Popover
+    className="jsp-spawner__image-options__packages-popover"
+    showClose
+    bodyContent={
+      <>
+        <span className="jsp-spawner__image-options__packages-popover__title">
+          Packages included:
+        </span>
+        {tag.content.dependencies.map((dependency) => (
+          <span
+            key={dependency.name}
+            className="jsp-spawner__image-options__packages-popover__package"
+          >
+            {getNameVersionString(dependency)}
+          </span>
+        ))}
+      </>
+    }
+  >
+    <OutlinedQuestionCircleIcon />
+  </Popover>
+);
+
+export default ImageTagPopover;

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonVariant, Label, Radio } from '@patternfly/react-core';
 import { AngleRightIcon, AngleDownIcon, StarIcon } from '@patternfly/react-icons';
 import { ImageType } from '../utils/types';
 import ImageTagPopover from './ImageTagPopover';
-import { getDescriptionForTag } from './imageUtils';
+import { getDescriptionForTag, getVersion } from './imageUtils';
 
 type ImageVersionsProps = {
   image: ImageType;
@@ -16,13 +16,6 @@ const ImageVersions: React.FC<ImageVersionsProps> = ({ image, selectedTag, onSel
   if (image.tags.length < 2) {
     return null;
   }
-
-  const getVersion = (version: string): string => {
-    if (version.startsWith('v') || version.startsWith('V')) {
-      return version.slice(1);
-    }
-    return version;
-  };
 
   return (
     <div className="jsp-spawner__image-options__tags">

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { Button, ButtonVariant, Label, Radio } from '@patternfly/react-core';
+import { AngleRightIcon, AngleDownIcon, StarIcon } from '@patternfly/react-icons';
+import { ImageType } from '../utils/types';
+import ImageTagPopover from './ImageTagPopover';
+import { getDescriptionForTag } from './imageUtils';
+
+type ImageVersionsProps = {
+  image: ImageType;
+  selectedTag?: string;
+  onSelect: (tagName: string, selected: boolean) => void;
+};
+
+const ImageVersions: React.FC<ImageVersionsProps> = ({ image, selectedTag, onSelect }) => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  if (image.tags.length < 2) {
+    return null;
+  }
+
+  const getVersion = (version: string): string => {
+    if (version.startsWith('v') || version.startsWith('V')) {
+      return version.slice(1);
+    }
+    return version;
+  };
+
+  return (
+    <div className="jsp-spawner__image-options__tags">
+      <Button variant={ButtonVariant.tertiary} onClick={() => setOpen(!open)}>
+        {open ? <AngleDownIcon /> : <AngleRightIcon />}
+        Versions
+      </Button>
+      {open ? (
+        <div className="jsp-spawner__image-options__tag-versions">
+          {image.tags.map((tag) => (
+            <Radio
+              key={tag.name}
+              id={tag.name}
+              name={tag.name}
+              className="jsp-spawner__image-options__option"
+              label={
+                <span className="jsp-spawner__image-options__title">
+                  <span className="jsp-spawner__image-options__title-version">
+                    Version{` ${getVersion(tag.name)}`}
+                  </span>
+                  <ImageTagPopover tag={tag} />
+                  {tag.recommended ? (
+                    <Label color="blue" icon={<StarIcon />}>
+                      Recommended
+                    </Label>
+                  ) : null}
+                </span>
+              }
+              description={getDescriptionForTag(tag)}
+              isChecked={tag.name === selectedTag}
+              onChange={(checked: boolean) => onSelect(tag.name, checked)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ImageVersions;

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
@@ -1,0 +1,11 @@
+import { ImageSoftwareType, ImageTagType } from '../utils/types';
+
+export const getNameVersionString = (software: ImageSoftwareType): string =>
+  `${software.name}${software.version ?? ''}`;
+
+export const getDescriptionForTag = (imageTag: ImageTagType): string => {
+  const softwareDescriptions = imageTag.content.software.map((software) =>
+    getNameVersionString(software),
+  );
+  return softwareDescriptions.join(', ');
+};

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
@@ -1,7 +1,17 @@
-import { ImageSoftwareType, ImageTagType } from '../utils/types';
+import { ImageSoftwareType, ImageTagType, ImageType } from '../utils/types';
+
+export const getVersion = (version?: string, prefix?: string): string => {
+  if (!version) {
+    return '';
+  }
+  const versionString =
+    version.startsWith('v') || version.startsWith('V') ? version.slice(1) : version;
+
+  return `${prefix ? prefix : ''}${versionString}`;
+};
 
 export const getNameVersionString = (software: ImageSoftwareType): string =>
-  `${software.name}${software.version ?? ''}`;
+  `${software.name}${getVersion(software.version, ' v')}`;
 
 export const getDescriptionForTag = (imageTag: ImageTagType): string => {
   const softwareDescriptions = imageTag.content.software.map((software) =>
@@ -9,3 +19,45 @@ export const getDescriptionForTag = (imageTag: ImageTagType): string => {
   );
   return softwareDescriptions.join(', ');
 };
+
+export const getDefaultTag = (image: ImageType): ImageTagType => {
+  if (image?.tags.length > 1) {
+    const defaultTag = image.tags.find((tag) => tag.recommended);
+    if (defaultTag) {
+      return defaultTag;
+    }
+  }
+  return image.tags[0];
+};
+
+export const getTagForImage = (
+  image: ImageType,
+  selectedImage?: string,
+  selectedTag?: string,
+): ImageTagType => {
+  let tag;
+  if (image.tags.length > 1) {
+    if (image.name === selectedImage && selectedTag) {
+      tag = image.tags.find((tag) => tag.name === selectedTag);
+    } else {
+      tag = getDefaultTag(image);
+    }
+  }
+  return tag || image.tags[0];
+};
+
+export const getImageTagVersion = (
+  image: ImageType,
+  selectedImage?: string,
+  selectedTag?: string,
+): string => {
+  if (image?.tags.length > 1) {
+    const defaultTag = getDefaultTag(image);
+    if (image.name === selectedImage && selectedTag) {
+      return `${selectedTag} ${selectedTag === defaultTag?.name ? ' (default)' : ''}`;
+    }
+    return defaultTag?.name ?? image.tags[0].name;
+  }
+  return '';
+};
+

--- a/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
@@ -1,4 +1,4 @@
-import { CM_PATH, SIZES_PATH, IMAGE_PATH, SINGLE_SIZE_PATH, UI_CONFIG_PATH } from '../utils/const';
+import { CM_PATH, SIZES_PATH, IMAGE_PATH, UI_CONFIG_PATH } from '../utils/const';
 import { ImageType, SizeDescription, UiConfigType, UserConfigMapType } from '../utils/types';
 
 type MockDataType = {
@@ -15,51 +15,212 @@ export const mockData: MockDataType = {
   [CM_PATH]: {
     env: [],
     gpu: 0,
-    last_selected_image: 's2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3',
+    last_selected_image: 's2i-generic-data-science-notebook:v0.0:4',
     last_selected_size: 'Default',
   },
   [SIZES_PATH]: ['Small', 'Medium', 'Large'],
   [IMAGE_PATH]: [
     {
+      build_status: 'Unknown',
+      default: false,
       description:
         'Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks',
-      url: 'https://github.com/thoth-station/s2i-generic-data-science-notebook',
       display_name: 'Standard Data Science',
-      name: 's2i-generic-data-science-notebook:v0.0.3',
-      content: {
-        software: [
-          {
-            name: 'Python',
-            version: 'v3.8.3',
+      name: 's2i-generic-data-science-notebook',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [
+              {
+                name: 'Boto3',
+                version: '1.17.11',
+              },
+              {
+                name: 'Kafka-Python',
+                version: '2.0.2',
+              },
+              {
+                name: 'Matplotlib',
+                version: '3.1.3',
+              },
+              {
+                name: 'Numpy',
+                version: '1.20.3',
+              },
+              {
+                name: 'Pandas',
+                version: '1.2.4',
+              },
+              {
+                name: 'Scipy',
+                version: '1.6.3',
+              },
+            ],
+            software: [
+              {
+                name: 'Python',
+                version: 'v3.8.3',
+              },
+            ],
           },
-        ],
-        dependencies: [
-          {
-            name: 'Boto3',
-            version: '1.17.11',
+          name: 'v0.0.4',
+          recommended: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-generic-data-science-notebook',
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description: 'Jupyter notebook image with Elyra-AI installed',
+      display_name: 'Elyra Notebook Image',
+      name: 's2i-lab-elyra',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [],
+            software: [],
           },
-          {
-            name: 'Kafka-Python',
-            version: '2.0.2',
+          name: 'v0.0.8',
+          recommended: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-lab-elyra',
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description:
+        'Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment.',
+      display_name: 'Minimal Python',
+      name: 's2i-minimal-notebook',
+      order: 10,
+      tags: [
+        {
+          content: {
+            dependencies: [
+              {
+                name: 'JupyterLab',
+                version: '3.0.14',
+              },
+              {
+                name: 'Notebook',
+                version: '6.3.0',
+              },
+            ],
+            software: [
+              {
+                name: 'Python',
+                version: 'v3.8.3',
+              },
+            ],
           },
-          {
-            name: 'Matplotlib',
-            version: '3.1.3',
+          name: 'v0.0.14',
+          recommended: true,
+        },
+        {
+          content: {
+            dependencies: [
+              {
+                name: 'JupyterLab',
+                version: '2.2.4',
+              },
+              {
+                name: 'Notebook',
+                version: '6.2.0',
+              },
+            ],
+            software: [
+              {
+                name: 'Python',
+                version: 'v3.6.8',
+              },
+            ],
           },
-          {
-            name: 'Numpy',
-            version: '1.20.2',
+          name: 'v0.0.7',
+          recommended: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-minimal-notebook',
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description:
+        'Jupyter notebook image containing basic dependencies for data science and machine learning work.',
+      display_name: 'SciPy Notebook Image',
+      name: 's2i-scipy-notebook',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [],
+            software: [],
           },
-          {
-            name: 'Pandas',
-            version: '1.2.3',
+          name: 'v0.0.2',
+          recommended: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-minimal-notebook',
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description: null,
+      display_name: 'Minimal Python with Apache Spark',
+      name: 's2i-spark-minimal-notebook',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [],
+            software: [],
           },
-          {
-            name: 'Scipy',
-            version: '1.6.2',
+          name: 'py36-spark2.4.5-hadoop2.7.3',
+          recommended: false,
+        },
+      ],
+      url: null,
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description: null,
+      display_name: 'Minimal Python with Apache Spark and SciPy',
+      name: 's2i-spark-scipy-notebook',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [],
+            software: [],
           },
-        ],
-      },
+          name: '3.6',
+          recommended: false,
+        },
+      ],
+      url: null,
+    },
+    {
+      build_status: 'Unknown',
+      default: false,
+      description: 'Jupyter notebook image containing dependencies for training Tensorflow models.',
+      display_name: 'Tensorflow Notebook Image',
+      name: 's2i-tensorflow-notebook',
+      order: 100,
+      tags: [
+        {
+          content: {
+            dependencies: [],
+            software: [],
+          },
+          name: 'v0.0.2',
+          recommended: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-tensorflow-notebook',
     },
   ],
   ['size/Small']: {

--- a/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
@@ -24,7 +24,7 @@ export const mockData: MockDataType = {
       build_status: 'Unknown',
       default: false,
       description:
-        'Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks',
+        'Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries available in all notebooks',
       display_name: 'Standard Data Science',
       name: 's2i-generic-data-science-notebook',
       order: 100,

--- a/jupyterhub_singleuser_profiles/ui/src/utils/types.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/types.ts
@@ -44,15 +44,24 @@ export type ImageSoftwareType = {
   version?: string;
 };
 
-export type ImageType = {
-  description: string;
-  url: string;
-  display_name: string;
-  name: string;
+export type ImageTagType = {
   content: {
     software: ImageSoftwareType[];
     dependencies: ImageSoftwareType[];
   };
+  name: string;
+  recommended: boolean;
+};
+
+export type ImageType = {
+  description: string | null;
+  url: string | null;
+  display_name: string;
+  name: string;
+  build_status: string | null;
+  default: boolean | undefined;
+  order: number;
+  tags: ImageTagType[];
 };
 
 export type SizeDescription = {


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-788

**Analysis / Root cause**: 
UI does not support new format of notebook image versions.

**Solution Description**: 
Update the UI to use the new data format retrieved for images. Show the different versions for the notebooks as radio buttons which allow the user to select their desired version. Indicate which version is recommended and order the notebooks based on the `order` field.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/123839892-aa357680-d8db-11eb-979d-95749fd492a9.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

/cc @kywalker-rh