### PR TITLE
Use the default tag if there is no prev or default image

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/App/App.scss
+++ b/jupyterhub_singleuser_profiles/ui/src/App/App.scss
@@ -21,7 +21,7 @@
     text-align: left;
     max-width: 768px;
 
-    &:first-of-type {
+    &.m-is-top {
       margin-top: 0;
       border-top: 0;
     }

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
@@ -25,7 +25,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
   handleSelection,
 }) => {
   const currentTag = getTagForImage(image, selectedImage, selectedTag);
-
+  const tags = image.tags || [];
   const getImagePopover = (image: ImageType) => {
     if (!image.description && !currentTag?.content?.dependencies?.length) {
       return null;
@@ -33,7 +33,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
     return <ImageTagPopover tag={currentTag} description={image.description || undefined} />;
   };
 
-  const disabled = image.tags.every((tag) => !isImageTagBuildValid(tag));
+  const disabled = tags.every((tag) => !isImageTagBuildValid(tag));
   const optionClasses = classNames('jsp-spawner__image-options__option', {
     'm-is-disabled': disabled,
   });
@@ -48,7 +48,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
         label={
           <span className="jsp-spawner__image-options__title">
             {image.display_name}
-            {image.tags.length > 1 ? (
+            {tags.length > 1 ? (
               <span className="jsp-spawner__image-options__title-version">
                 {getImageTagVersion(image, selectedImage, selectedTag)}
               </span>
@@ -58,7 +58,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
         }
         description={getDescriptionForTag(currentTag)}
         isChecked={image.name === selectedImage}
-        onChange={(checked: boolean) => handleSelection(image, currentTag.name, checked)}
+        onChange={(checked: boolean) => handleSelection(image, currentTag?.name || '', checked)}
       />
       <ImageVersions
         image={image}

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageTagPopover.tsx
@@ -5,12 +5,16 @@ import { ImageTagType } from '../utils/types';
 import { getNameVersionString } from './imageUtils';
 
 type ImageTagPopoverProps = {
-  tag: ImageTagType;
+  tag?: ImageTagType;
   description?: string;
 };
 
 const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag, description }) => {
   const [isVisible, setIsVisible] = React.useState(false);
+  const dependencies = tag?.content?.dependencies ?? [];
+  if (!description && !dependencies.length) {
+    return null;
+  }
   return (
     <Popover
       className="jsp-spawner__image-options__packages-popover"
@@ -31,12 +35,12 @@ const ImageTagPopover: React.FC<ImageTagPopoverProps> = ({ tag, description }) =
               {description}
             </span>
           ) : null}
-          {tag.content?.dependencies?.length > 0 ? (
+          {dependencies.length > 0 ? (
             <>
               <span className="jsp-spawner__image-options__packages-popover__package-title">
                 Packages included:
               </span>
-              {tag.content.dependencies.map((dependency) => (
+              {dependencies.map((dependency) => (
                 <span
                   key={dependency.name}
                   className="jsp-spawner__image-options__packages-popover__package"

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
@@ -15,7 +15,7 @@ type ImageVersionsProps = {
 
 const ImageVersions: React.FC<ImageVersionsProps> = ({ image, selectedTag, onSelect }) => {
   const [open, setOpen] = React.useState<boolean>(false);
-  if (image.tags.length < 2) {
+  if (!image.tags || image.tags.length < 2) {
     return null;
   }
 
@@ -36,9 +36,9 @@ const ImageVersions: React.FC<ImageVersionsProps> = ({ image, selectedTag, onSel
               });
               return (
                 <Radio
-                  key={tag.name}
-                  id={tag.name}
-                  name={tag.name}
+                  key={`${image.name}:${tag.name}`}
+                  id={`${image.name}:${tag.name}`}
+                  name={`${image.name}:${tag.name}`}
                   className={classes}
                   isDisabled={disabled}
                   label={

--- a/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
@@ -1,4 +1,10 @@
-import { CM_PATH, SIZES_PATH, IMAGE_PATH, UI_CONFIG_PATH } from '../utils/const';
+import {
+  CM_PATH,
+  SIZES_PATH,
+  IMAGE_PATH,
+  UI_CONFIG_PATH,
+  DEFAULT_IMAGE_PATH,
+} from '../utils/const';
 import { ImageType, SizeDescription, UiConfigType, UserConfigMapType } from '../utils/types';
 
 type MockDataType = {
@@ -9,19 +15,20 @@ type MockDataType = {
   ['size/Medium']: SizeDescription;
   ['size/Large']: SizeDescription;
   [UI_CONFIG_PATH]: UiConfigType;
+  [DEFAULT_IMAGE_PATH]: string;
 };
 
 export const mockData: MockDataType = {
   [CM_PATH]: {
     env: [],
     gpu: 0,
-    last_selected_image: 's2i-generic-data-science-notebook:v0.0:4',
+    last_selected_image: 's2i-generic-data-science-notebook:v0.0.24',
     last_selected_size: 'Default',
   },
+  [DEFAULT_IMAGE_PATH]: 's2i-generic-data-science-notebook:v0.0.4',
   [SIZES_PATH]: ['Small', 'Medium', 'Large'],
   [IMAGE_PATH]: [
     {
-      default: false,
       description:
         'Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries available in all notebooks',
       display_name: 'Standard Data Science',
@@ -66,6 +73,7 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.4',
           recommended: false,
+          default: true,
         },
         {
           build_status: 'Unknown',
@@ -105,12 +113,12 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.24',
           recommended: true,
+          default: false,
         },
       ],
       url: 'https://github.com/thoth-station/s2i-generic-data-science-notebook',
     },
     {
-      default: false,
       description: 'Jupyter notebook image with Elyra-AI installed',
       display_name: 'Elyra Notebook Image',
       name: 's2i-lab-elyra',
@@ -129,12 +137,12 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.8',
           recommended: false,
+          default: false,
         },
       ],
       url: 'https://github.com/thoth-station/s2i-lab-elyra',
     },
     {
-      default: false,
       description:
         'Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment.',
       display_name: 'Minimal Python',
@@ -163,6 +171,7 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.14',
           recommended: true,
+          default: false,
         },
         {
           build_status: 'Unknown',
@@ -186,12 +195,12 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.7',
           recommended: false,
+          default: false,
         },
       ],
       url: 'https://github.com/thoth-station/s2i-minimal-notebook',
     },
     {
-      default: false,
       description:
         'Jupyter notebook image containing basic dependencies for data science and machine learning work.',
       display_name: 'SciPy Notebook Image',
@@ -211,12 +220,12 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.2',
           recommended: false,
+          default: false,
         },
       ],
       url: 'https://github.com/thoth-station/s2i-minimal-notebook',
     },
     {
-      default: false,
       description: null,
       display_name: 'Minimal Python with Apache Spark',
       name: 's2i-spark-minimal-notebook',
@@ -230,19 +239,19 @@ export const mockData: MockDataType = {
           },
           name: 'py36-spark2.4.5-hadoop2.7.3',
           recommended: false,
+          default: false,
         },
       ],
       url: null,
     },
     {
-      default: false,
       description: null,
       display_name: 'Minimal Python with Apache Spark and SciPy',
       name: 's2i-spark-scipy-notebook',
       order: 100,
       tags: [
         {
-          build_status: 'Unknown',
+          build_status: 'failed',
           content: {
             dependencies: [],
             software: [
@@ -254,21 +263,22 @@ export const mockData: MockDataType = {
           },
           name: '3.6',
           recommended: false,
+          default: false,
         },
         {
-          build_status: 'Unknown',
+          build_status: 'pending',
           content: {
             dependencies: [],
             software: [],
           },
           name: '3.5.2',
           recommended: true,
+          default: false,
         },
       ],
       url: null,
     },
     {
-      default: false,
       description: 'Jupyter notebook image containing dependencies for training Tensorflow models.',
       display_name: 'Tensorflow Notebook Image',
       name: 's2i-tensorflow-notebook',
@@ -291,8 +301,56 @@ export const mockData: MockDataType = {
           },
           name: 'v0.0.2',
           recommended: false,
+          default: false,
         },
       ],
+      url: 'https://github.com/thoth-station/s2i-tensorflow-notebook',
+    },
+    {
+      description: 'Jupyter notebook image containing dependencies for training Tensorflow models.',
+      display_name: 'No Tag Content Notebook Image',
+      name: 'no-tag-content-notebook',
+      order: 100,
+      tags: [
+        {
+          build_status: 'Unknown',
+          name: 'v0.0.2',
+          recommended: false,
+          default: false,
+        },
+        {
+          build_status: 'Unknown',
+          content: {
+            dependencies: [],
+            software: [
+              {
+                name: 'Python',
+                version: 'v3.8.7',
+              },
+              {
+                name: 'Tensorflow CPU',
+                version: 'v2.4.0',
+              },
+            ],
+          },
+          name: 'v0.0.3',
+          recommended: false,
+          default: false,
+        },
+        {
+          build_status: 'Unknown',
+          name: 'v0.0.4',
+          recommended: false,
+          default: false,
+        },
+      ],
+      url: 'https://github.com/thoth-station/s2i-tensorflow-notebook',
+    },
+    {
+      description: 'Jupyter notebook image containing dependencies for training Tensorflow models.',
+      display_name: 'No Tags Notebook Image',
+      name: 'no-tags-notebook',
+      order: 100,
       url: 'https://github.com/thoth-station/s2i-tensorflow-notebook',
     },
   ],

--- a/jupyterhub_singleuser_profiles/ui/src/utils/types.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/types.ts
@@ -33,7 +33,7 @@ export type EnvVarType = {
 };
 
 export type UserConfigMapType = {
-  env: EnvVarType[];
+  env?: EnvVarType[];
   gpu: number;
   last_selected_image: string;
   last_selected_size: string;
@@ -45,12 +45,13 @@ export type ImageSoftwareType = {
 };
 
 export type ImageTagType = {
-  content: {
+  content?: {
     software: ImageSoftwareType[];
     dependencies: ImageSoftwareType[];
   };
   name: string;
   recommended: boolean;
+  default: boolean | undefined;
   build_status: string | null;
 };
 
@@ -59,9 +60,8 @@ export type ImageType = {
   url: string | null;
   display_name: string;
   name: string;
-  default: boolean | undefined;
   order: number;
-  tags: ImageTagType[];
+  tags?: ImageTagType[];
 };
 
 export type SizeDescription = {


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1464

**Analysis / Root cause**: 
The JSP Spawner UI should auto select the notebook based on:

1. Previous selection
2. Set default notebook image
3. Image tag with field `default` set to true

Currently, the default field is not used to determine the selection when neither of the first 2 conditions are not set.

**Solution Description**: 
If there is no default or preselected image/tag, find the tag with default set to true and pre-select that.
Also handle empty tags and tags with empty content.

