### PR TITLE
Fix username read issue in frontend API call

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
@@ -13,8 +13,8 @@ const getForUser = () => {
   // @ts-ignore
   const jhdata = window.jhdata;
 
-  if (jhdata?.['for_user']) {
-    return jhdata['for_user'];
+  if (jhdata?.['user']) {
+    return jhdata['user'];
   }
   return null;
 };


### PR DESCRIPTION
There is no `for_user` field in `window.jhdata`. In order to get the correct username, we should read it from `user` field.
<img width="685" alt="Screen Shot 2021-07-23 at 10 33 54 AM" src="https://user-images.githubusercontent.com/37624318/127169792-125e8d0a-2148-4885-ba0f-346e26a215ab.png">
