### PR TITLE
Handle image tags with invalid semantic versions

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageVersions.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import compareVersions from 'compare-versions';
 import { Button, ButtonVariant, Label, Radio } from '@patternfly/react-core';
 import { AngleRightIcon, AngleDownIcon, StarIcon } from '@patternfly/react-icons';
 import { ImageType } from '../utils/types';
 import ImageTagPopover from './ImageTagPopover';
-import { getDescriptionForTag, getVersion, isImageTagBuildValid } from './imageUtils';
+import {
+  compareTagVersions,
+  getDescriptionForTag,
+  getVersion,
+  isImageTagBuildValid,
+} from './imageUtils';
 
 type ImageVersionsProps = {
   image: ImageType;
@@ -27,37 +31,35 @@ const ImageVersions: React.FC<ImageVersionsProps> = ({ image, selectedTag, onSel
       </Button>
       {open ? (
         <div className="jsp-spawner__image-options__tag-versions">
-          {image.tags
-            .sort((a, b) => compareVersions(b.name, a.name))
-            .map((tag) => {
-              const disabled = !isImageTagBuildValid(tag);
-              const classes = classNames('jsp-spawner__image-options__option', {
-                'm-is-disabled': disabled,
-              });
-              return (
-                <Radio
-                  key={`${image.name}:${tag.name}`}
-                  id={`${image.name}:${tag.name}`}
-                  name={`${image.name}:${tag.name}`}
-                  className={classes}
-                  isDisabled={disabled}
-                  label={
-                    <span className="jsp-spawner__image-options__title">
-                      Version{` ${getVersion(tag.name)}`}
-                      <ImageTagPopover tag={tag} />
-                      {tag.recommended ? (
-                        <Label color="blue" icon={<StarIcon />}>
-                          Recommended
-                        </Label>
-                      ) : null}
-                    </span>
-                  }
-                  description={getDescriptionForTag(tag)}
-                  isChecked={tag.name === selectedTag}
-                  onChange={(checked: boolean) => onSelect(tag.name, checked)}
-                />
-              );
-            })}
+          {image.tags.sort(compareTagVersions).map((tag) => {
+            const disabled = !isImageTagBuildValid(tag);
+            const classes = classNames('jsp-spawner__image-options__option', {
+              'm-is-disabled': disabled,
+            });
+            return (
+              <Radio
+                key={`${image.name}:${tag.name}`}
+                id={`${image.name}:${tag.name}`}
+                name={`${image.name}:${tag.name}`}
+                className={classes}
+                isDisabled={disabled}
+                label={
+                  <span className="jsp-spawner__image-options__title">
+                    Version{` ${getVersion(tag.name)}`}
+                    <ImageTagPopover tag={tag} />
+                    {tag.recommended ? (
+                      <Label color="blue" icon={<StarIcon />}>
+                        Recommended
+                      </Label>
+                    ) : null}
+                  </span>
+                }
+                description={getDescriptionForTag(tag)}
+                isChecked={tag.name === selectedTag}
+                onChange={(checked: boolean) => onSelect(tag.name, checked)}
+              />
+            );
+          })}
         </div>
       ) : null}
     </div>

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/imageUtils.ts
@@ -4,6 +4,13 @@ import { ImageSoftwareType, ImageTagType, ImageType } from '../utils/types';
 const runningStatuses = ['pending', 'running', 'cancelled'];
 const failedStatuses = ['error', 'failed'];
 
+export const compareTagVersions = (a: ImageTagType, b: ImageTagType): number => {
+  if (compareVersions.validate(a.name) && compareVersions.validate(b.name)) {
+    return compareVersions(b.name, a.name);
+  }
+  return b.name.localeCompare(a.name);
+};
+
 export const isImageBuildInProgress = (image: ImageType): boolean => {
   const inProgressTag = image.tags?.find((tag) =>
     runningStatuses.includes(tag.build_status?.toLowerCase() ?? ''),
@@ -60,7 +67,7 @@ export const getDefaultTag = (image: ImageType): ImageTagType | undefined => {
   }
 
   // Return the most recent version
-  return tags.sort((a, b) => compareVersions(b.name, a.name))[0];
+  return tags.sort(compareTagVersions)[0];
 };
 
 export const getTagForImage = (

--- a/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
@@ -197,6 +197,30 @@ export const mockData: MockDataType = {
           recommended: false,
           default: false,
         },
+        {
+          build_status: 'Unknown',
+          content: {
+            dependencies: [
+              {
+                name: 'JupyterLab',
+                version: '2.2.4',
+              },
+              {
+                name: 'Notebook',
+                version: '6.2.0',
+              },
+            ],
+            software: [
+              {
+                name: 'Python',
+                version: 'v3.6.8',
+              },
+            ],
+          },
+          name: 'v1.0.0',
+          recommended: false,
+          default: false,
+        },
       ],
       url: 'https://github.com/thoth-station/s2i-minimal-notebook',
     },
@@ -314,7 +338,7 @@ export const mockData: MockDataType = {
       tags: [
         {
           build_status: 'Unknown',
-          name: 'v0.0.2',
+          name: 'notag-3.8-badsemver-1.4.1',
           recommended: false,
           default: false,
         },
@@ -333,7 +357,7 @@ export const mockData: MockDataType = {
               },
             ],
           },
-          name: 'v0.0.3',
+          name: 'notag-3.8-badsemver-1.0.3',
           recommended: false,
           default: false,
         },


### PR DESCRIPTION
**Fixes**: 
JIRA: https://issues.redhat.com/browse/ODH-434

**Analysis / Root cause**: 
The versions of the image tags were sorted using `compare-versions`. That function fails if one of the versions is not a correct semantic version format.

**Solution Description**: 
Update the sorting to validate the versions before using `compare-versions` if not valid, do a simple string compare.

