### PR TITLE
Add notebook_namespace parameter for cm and secrets

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -16,7 +16,9 @@ from flask import Response
 
 from jupyterhub.services.auth import HubAuth
 
-_PROFILES = SingleuserProfiles(verify_ssl=False)
+custom_notebook_namespace = os.environ['NOTEBOOK_NAMESPACE']
+
+_PROFILES = SingleuserProfiles(notebook_namespace=custom_notebook_namespace, verify_ssl=False)
 _PROFILES.load_profiles()
 
 _LOGGER = logging.getLogger(__name__)

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -24,7 +24,7 @@ _GPU_KEY = "nvidia.com/gpu"
 class SingleuserProfiles(object):
   GPU_MODE_SELINUX = "selinux"
   GPU_MODE_PRIVILEGED = "privileged"
-  def __init__(self, namespace=None, verify_ssl=True, gpu_mode=None, service_account_path='/var/run/secrets/kubernetes.io/serviceaccount'):
+  def __init__(self, namespace=None, notebook_namespace=None, verify_ssl=True, gpu_mode=None, service_account_path='/var/run/secrets/kubernetes.io/serviceaccount'):
     self.profiles = []
     self.namespace = None
     self.gpu_types = []
@@ -35,7 +35,7 @@ class SingleuserProfiles(object):
 
     self.service = Service(self.openshift, self.namespace)
     self.images = Images(self.openshift, namespace=namespace)
-    self.user = User(self.openshift, default_image=self.images.get_default())
+    self.user = User(self.openshift, default_image=self.images.get_default(), notebook_namespace=notebook_namespace)
 
   @property
   def gpu_mode(self):

--- a/jupyterhub_singleuser_profiles/user.py
+++ b/jupyterhub_singleuser_profiles/user.py
@@ -17,9 +17,10 @@ class User(object):
   _TYPE_SECRET = "password"
   _TYPE_ENV = "text"
 
-  def __init__(self, openshift, default_image):
+  def __init__(self, openshift, default_image, notebook_namespace=None):
       self.openshift = openshift
       self._DEFAULT_IMAGE = default_image
+      self.notebook_namespace = notebook_namespace
 
   # THis method is going to be removed in the future
   def fix_if_legacy(self, username, cm):
@@ -65,12 +66,12 @@ class User(object):
 
   def save_envs(self, username, data):
     name = self._USER_ENVS_TEMPLATE % escape(username)
-    self.openshift.write_config_map(name, self.get_envs_from_data(data))
+    self.openshift.write_config_map(name, self.get_envs_from_data(data), notebook_namespace=self.notebook_namespace)
 
   def get_envs(self, username, for_k8s=False):
     result = []
     name = self._USER_ENVS_TEMPLATE % escape(username)
-    data = self.openshift.read_config_map(name)
+    data = self.openshift.read_config_map(name, notebook_namespace=self.notebook_namespace)
     if data:
       result = [{"name": key, "type": self._TYPE_ENV, "value": value} for key, value in data.items()]
 
@@ -81,12 +82,12 @@ class User(object):
 
   def save_secrets(self, username, data):
     name = self._USER_ENVS_TEMPLATE % escape(username)
-    self.openshift.write_secret(name, self.get_secrets_from_data(data))
+    self.openshift.write_secret(name, self.get_secrets_from_data(data), notebook_namespace=self.notebook_namespace)
 
   def get_secrets(self, username, for_k8s=False):
     result = []
     name = self._USER_ENVS_TEMPLATE % escape(username)
-    data = self.openshift.read_secret(name)
+    data = self.openshift.read_secret(name, notebook_namespace=self.notebook_namespace)
     if data:
       result = [{"name": key, "type": self._TYPE_SECRET, "value": value} for key, value in data.items()]
 


### PR DESCRIPTION
This change is required for Jupyter server pod placement in custom namespaces. This PR is part of the RHODS-1641 issue

It adds a new parameter in SingleUserProfiles, User, and OpenShift classes named `notebook_namespace` for that case.