### PR TITLE
Change custom namespace gathering to allow unset namespace

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -16,7 +16,7 @@ from flask import Response
 
 from jupyterhub.services.auth import HubAuth
 
-custom_notebook_namespace = os.environ['NOTEBOOK_NAMESPACE']
+custom_notebook_namespace = os.environ.get('NOTEBOOK_NAMESPACE')
 
 _PROFILES = SingleuserProfiles(notebook_namespace=custom_notebook_namespace, verify_ssl=False)
 _PROFILES.load_profiles()


### PR DESCRIPTION
Changes the environ gather to a .get() so jsp does not crash if NOTEBOOK_NAMESPACE is unset.