### PR TITLE
Add size capacity request

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -80,9 +80,9 @@ def whoami(user):
 def get_instance(*args, **kwargs):
     return _PROFILES.get_instance()
 
-@authenticated
-def get_size_capacity(*args, **kwargs):
-    return _PROFILES.get_size_capacity()
+#@authenticated
+#def get_size_capacity(*args, **kwargs):
+#    return _PROFILES.get_size_capacity()
 
 @authenticated
 def get_user_cm(user):

--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -81,6 +81,10 @@ def get_instance(*args, **kwargs):
     return _PROFILES.get_instance()
 
 @authenticated
+def get_size_capacity(*args, **kwargs):
+    return _PROFILES.get_size_capacity()
+
+@authenticated
 def get_user_cm(user):
     cm = _PROFILES.user.get(user['name'])
     return cm

--- a/jupyterhub_singleuser_profiles/api/swagger.yaml
+++ b/jupyterhub_singleuser_profiles/api/swagger.yaml
@@ -114,6 +114,18 @@ paths:
               schema:
                 type: string
 
+  /api/sizes/capacity:
+    get:
+      operationId: jupyterhub_singleuser_profiles.api.api.get_size_capacity
+      summary: Get a json with sums of total and allocated resources of all nodes
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SizeCap"
+
   /api/sizes:
     get:
       operationId: jupyterhub_singleuser_profiles.api.api.get_sizes
@@ -415,4 +427,16 @@ components:
         cluster_id:
           title: Cluster ID
           type: string
+    SizeCap:
+      title: SizeCap
+      type: object
+      properties:
+        cpu:
+          type: integer
+        allocatable_cpu:
+          type: integer
+        memory:
+          type: integer
+        allocatable_memory:
+          type: integer
       

--- a/jupyterhub_singleuser_profiles/api/swagger.yaml
+++ b/jupyterhub_singleuser_profiles/api/swagger.yaml
@@ -114,17 +114,17 @@ paths:
               schema:
                 type: string
 
-  /api/sizes/capacity:
-    get:
-      operationId: jupyterhub_singleuser_profiles.api.api.get_size_capacity
-      summary: Get a json with sums of total and allocated resources of all nodes
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SizeCap"
+  # /api/sizes/capacity:
+  #   get:
+  #     operationId: jupyterhub_singleuser_profiles.api.api.get_size_capacity
+  #     summary: Get a json with sums of total and allocated resources of all nodes
+  #     responses:
+  #       '200':
+  #         description: OK
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/SizeCap"
 
   /api/sizes:
     get:
@@ -427,16 +427,16 @@ components:
         cluster_id:
           title: Cluster ID
           type: string
-    SizeCap:
-      title: SizeCap
-      type: object
-      properties:
-        cpu:
-          type: integer
-        allocatable_cpu:
-          type: integer
-        memory:
-          type: integer
-        allocatable_memory:
-          type: integer
+    # SizeCap:
+    #   title: SizeCap
+    #   type: object
+    #   properties:
+    #     cpu:
+    #       type: integer
+    #     allocatable_cpu:
+    #       type: integer
+    #     memory:
+    #       type: integer
+    #     allocatable_memory:
+    #       type: integer
       

--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -169,21 +169,28 @@ class OpenShift(object):
     memory = 0
     memory_alloc = 0
     node_list = self.get_nodes()
+    node_cap_list = []
     for node in node_list.items:
       cpu_str = node.status.capacity.get('cpu')
-      cpu += self.calc_cpu(cpu_str)
+      cpu = self.calc_cpu(cpu_str)
       cpu_str = node.status.allocatable.get('cpu')
-      cpu_alloc += self.calc_cpu(cpu_str)
+      cpu_alloc = self.calc_cpu(cpu_str)
       memory_str = node.status.capacity.get('memory')
-      memory += self.calc_memory(memory_str)
+      memory = self.calc_memory(memory_str)
       memory_str = node.status.allocatable.get('memory')
-      memory_alloc += self.calc_memory(memory_str)
-    return {
+      memory_alloc = self.calc_memory(memory_str)
+      
+      node_cap_list.append({
       'cpu': cpu,
       'allocatable_cpu': cpu_alloc,
       'memory': memory,
       'allocatable_memory': memory_alloc
-    }
+      })
+    node_cap_list.sort(key=lambda cap_dict:(cap_dict['allocatable_memory'],
+                                            cap_dict['memory'],
+                                            cap_dict['allocatable_cpu'],
+                                            cap_dict['cpu']))
+    return node_cap_list
     
   def get_imagestreams(self, label=None):
     imagestreams = self.oapi_client.resources.get(kind='ImageStream', api_version='image.openshift.io/v1')

--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -140,20 +140,20 @@ class OpenShift(object):
     return node_list
 
   def calc_cpu(self, cpu_str):
-    if cpu_str[-1] == 'm':
-      cpu = int(cpu_str[:-1])/1000
+    if type(cpu_str) != int and cpu_str[-1] == 'm': #Can sometimes be int
+      cpu = float(cpu_str[:-1])/1000
     else:
-      cpu = int(cpu_str)
+      cpu = float(cpu_str)
     return cpu
 
   # Returns memory in Gi
   def calc_memory(self, memory_str):
     if memory_str[-2:] == 'Ki':
-      memory = int(memory_str[:-2])/1000000 
+      memory = float(memory_str[:-2])/1000000 
     elif memory_str[-2:] == 'Mi':
-      memory = int(memory_str[:-2])/1000
+      memory = float(memory_str[:-2])/1000
     elif memory_str[-2:] == 'Gi':
-      memory = int(memory_str[:-2])
+      memory = float(memory_str[:-2])
     return memory
 
   def get_gpu_number(self):
@@ -187,8 +187,8 @@ class OpenShift(object):
       'allocatable_memory': memory_alloc
       })
     node_cap_list.sort(key=lambda cap_dict:(cap_dict['allocatable_memory'],
-                                            cap_dict['memory'],
                                             cap_dict['allocatable_cpu'],
+                                            cap_dict['memory'],
                                             cap_dict['cpu']))
     return node_cap_list
     

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -110,7 +110,7 @@ class SingleuserProfiles(object):
       res = self.merge_profiles(res, p)
 
     if size:
-      s = Sizes(self.sizes)
+      s = Sizes(self.sizes, self.openshift)
       loaded_size = s.get_size(size)
       if loaded_size:
         res = self.merge_profiles(res, loaded_size)
@@ -151,21 +151,22 @@ class SingleuserProfiles(object):
       'cluster_id': cluster_version.spec.get('clusterID')
     }
   
-  def get_size_capacity(self):
-    return self.openshift.get_node_capacity()
+  #def get_size_capacity(self):
+  #  return self.openshift.get_node_capacity()
     
 
   def get_sizes_form(self, username=None):
     if not self.profiles:
       self.load_profiles(username=username)
-    s = Sizes(self.sizes)
+    s = Sizes(self.sizes, self.openshift)
     return s.get_form(self.get_profile_by_name(_USER_CONFIG_PROFILE_NAME).get('last_selected_size'))
 
   def get_size(self, size):
-    s = Sizes(self.sizes)
+    s = Sizes(self.sizes, self.openshift)
     return s.get_size(size)
-    
+
   def get_sizes(self):
+    s = Sizes(self.sizes, self.openshift)
     return self.sizes
 
   def get_image_info(self, image_name):

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -13,6 +13,7 @@ from .images import Images
 from .ui_config import UIConfig
 from .openshift import OpenShift
 from .user import User
+from jupyterhub_singleuser_profiles import sizes
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,6 +150,9 @@ class SingleuserProfiles(object):
       'segment_key': segment_key,
       'cluster_id': cluster_version.spec.get('clusterID')
     }
+  
+  def get_size_capacity(self):
+    return self.openshift.get_node_capacity()
     
 
   def get_sizes_form(self, username=None):

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -167,7 +167,7 @@ class SingleuserProfiles(object):
 
   def get_sizes(self):
     s = Sizes(self.sizes, self.openshift)
-    return self.sizes
+    return s.sizes
 
   def get_image_info(self, image_name):
     return self.images.get_info(image_name)

--- a/jupyterhub_singleuser_profiles/sizes.py
+++ b/jupyterhub_singleuser_profiles/sizes.py
@@ -5,11 +5,33 @@ from .utils import parse_resources
 
 
 _LOGGER = logging.getLogger(__name__)
-
+    
 class Sizes(object):
     def __init__(self, sizes, openshift):
-        self.sizes = sizes
+        self._sizes = sizes
         self.openshift = openshift
+
+    def add_label(self):
+
+        for size in self._sizes:
+            capacity_list = self.openshift.get_node_capacity()
+            mem = self.openshift.calc_memory(size['resources']['limits'].get('memory'))
+            cpu = self.openshift.calc_cpu(size['resources']['limits'].get('cpu'))
+            # Search sorted capacity list from lowest node capacity up
+            for node_cap in capacity_list:
+                if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
+                    size['schedulable'] = True #Small enough
+                    break
+                elif mem < node_cap['memory'] and cpu < node_cap['cpu']:
+                    size['schedulable'] = None #Maybe (Warn user)
+                    break
+                else:
+                    size['schedulable'] = False #Too big (Do not show)
+
+    @property
+    def sizes(self):
+        self.add_label()
+        return self._sizes
 
     def get_size(self, size):
         result = {}
@@ -36,25 +58,7 @@ class Sizes(object):
         else:
             size = None
 
-        return size
-
-    def add_warnings(self):
-
-        for size in self.sizes:
-            capacity_list = self.openshift.get_node_capacity()
-            mem = self.openshift.calc_memory(size['resource']['limits'].get('memory'))
-            cpu = self.openshift.calc_cpu(size['resource']['limits'].get('cpu'))
-            # Search sorted capacity list from lowest node capacity up
-            for node_cap in capacity_list:
-                if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
-                    size['warning'] = 'none'
-                    break
-                elif mem < node_cap['memory'] and cpu < node_cap['cpu']:
-                    size['warning'] = 'warn'
-                    break
-                else:
-                    size['warning'] = 'ignore'
-                        
+        return size                        
 
     def get_form(self, last_size=None):
         template = """

--- a/jupyterhub_singleuser_profiles/sizes.py
+++ b/jupyterhub_singleuser_profiles/sizes.py
@@ -7,8 +7,9 @@ from .utils import parse_resources
 _LOGGER = logging.getLogger(__name__)
 
 class Sizes(object):
-    def __init__(self, sizes):
+    def __init__(self, sizes, openshift):
         self.sizes = sizes
+        self.openshift = openshift
 
     def get_size(self, size):
         result = {}
@@ -36,6 +37,24 @@ class Sizes(object):
             size = None
 
         return size
+
+    def add_warnings(self):
+
+        for size in self.sizes:
+            capacity_list = self.openshift.get_node_capacity()
+            mem = self.openshift.calc_memory(size['resource']['limits'].get('memory'))
+            cpu = self.openshift.calc_cpu(size['resource']['limits'].get('cpu'))
+            # Search sorted capacity list from lowest node capacity up
+            for node_cap in capacity_list:
+                if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
+                    size['warning'] = 'none'
+                    break
+                elif mem < node_cap['memory'] and cpu < node_cap['cpu']:
+                    size['warning'] = 'warn'
+                    break
+                else:
+                    size['warning'] = 'ignore'
+                        
 
     def get_form(self, last_size=None):
         template = """


### PR DESCRIPTION
Adds an API call which returns the sum of allocatable and total memory on nodes and the same for CPUs.

Example output: ```{
  "allocatable_cpu": 21,
  "allocatable_memory": 91.55020800000001,
  "cpu": 24,
  "memory": 98.45606400000001
} ```