### PR TITLE
Label all sizes to show if they will be schedulable on the cluster

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -82,6 +82,10 @@ def whoami(user):
 def get_instance(*args, **kwargs):
     return _PROFILES.get_instance()
 
+#@authenticated
+#def get_size_capacity(*args, **kwargs):
+#    return _PROFILES.get_size_capacity()
+
 @authenticated
 def get_user_cm(user):
     cm = _PROFILES.user.get(user['name'])

--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -82,10 +82,6 @@ def whoami(user):
 def get_instance(*args, **kwargs):
     return _PROFILES.get_instance()
 
-#@authenticated
-#def get_size_capacity(*args, **kwargs):
-#    return _PROFILES.get_size_capacity()
-
 @authenticated
 def get_user_cm(user):
     cm = _PROFILES.user.get(user['name'])

--- a/jupyterhub_singleuser_profiles/api/swagger.yaml
+++ b/jupyterhub_singleuser_profiles/api/swagger.yaml
@@ -114,18 +114,6 @@ paths:
               schema:
                 type: string
 
-  # /api/sizes/capacity:
-  #   get:
-  #     operationId: jupyterhub_singleuser_profiles.api.api.get_size_capacity
-  #     summary: Get a json with sums of total and allocated resources of all nodes
-  #     responses:
-  #       '200':
-  #         description: OK
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/SizeCap"
-
   /api/sizes:
     get:
       operationId: jupyterhub_singleuser_profiles.api.api.get_sizes
@@ -427,16 +415,3 @@ components:
         cluster_id:
           title: Cluster ID
           type: string
-    # SizeCap:
-    #   title: SizeCap
-    #   type: object
-    #   properties:
-    #     cpu:
-    #       type: integer
-    #     allocatable_cpu:
-    #       type: integer
-    #     memory:
-    #       type: integer
-    #     allocatable_memory:
-    #       type: integer
-      

--- a/jupyterhub_singleuser_profiles/api/swagger.yaml
+++ b/jupyterhub_singleuser_profiles/api/swagger.yaml
@@ -114,6 +114,18 @@ paths:
               schema:
                 type: string
 
+  # /api/sizes/capacity:
+  #   get:
+  #     operationId: jupyterhub_singleuser_profiles.api.api.get_size_capacity
+  #     summary: Get a json with sums of total and allocated resources of all nodes
+  #     responses:
+  #       '200':
+  #         description: OK
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/SizeCap"
+
   /api/sizes:
     get:
       operationId: jupyterhub_singleuser_profiles.api.api.get_sizes
@@ -415,4 +427,16 @@ components:
         cluster_id:
           title: Cluster ID
           type: string
+    # SizeCap:
+    #   title: SizeCap
+    #   type: object
+    #   properties:
+    #     cpu:
+    #       type: integer
+    #     allocatable_cpu:
+    #       type: integer
+    #     memory:
+    #       type: integer
+    #     allocatable_memory:
+    #       type: integer
       

--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -134,13 +134,63 @@ class OpenShift(object):
       else:
         raise
 
-  def get_gpu_number(self):
-    result = 0
+  def get_nodes(self):
     nodes = self.oapi_client.resources.get(kind='Node', api_version='v1')
     node_list = nodes.get()
+    return node_list
+
+  def calc_cpu(self, cpu_str):
+    if type(cpu_str) != int and cpu_str[-1] == 'm': #Can sometimes be int
+      cpu = float(cpu_str[:-1])/1000
+    else:
+      cpu = float(cpu_str)
+    return cpu
+
+  # Returns memory in Gi
+  def calc_memory(self, memory_str):
+    if memory_str[-2:] == 'Ki':
+      memory = float(memory_str[:-2])/1000000 
+    elif memory_str[-2:] == 'Mi':
+      memory = float(memory_str[:-2])/1000
+    elif memory_str[-2:] == 'Gi':
+      memory = float(memory_str[:-2])
+    return memory
+
+  def get_gpu_number(self):
+    result = 0
+    node_list = self.get_nodes()
     for node in node_list.items:
       result += int(node.metadata.labels.get('nvidia.com/gpu.count', 0))
-    return result      
+    return result     
+
+  def get_node_capacity(self):
+    cpu = 0
+    cpu_alloc = 0
+    memory = 0
+    memory_alloc = 0
+    node_list = self.get_nodes()
+    node_cap_list = []
+    for node in node_list.items:
+      cpu_str = node.status.capacity.get('cpu')
+      cpu = self.calc_cpu(cpu_str)
+      cpu_str = node.status.allocatable.get('cpu')
+      cpu_alloc = self.calc_cpu(cpu_str)
+      memory_str = node.status.capacity.get('memory')
+      memory = self.calc_memory(memory_str)
+      memory_str = node.status.allocatable.get('memory')
+      memory_alloc = self.calc_memory(memory_str)
+      
+      node_cap_list.append({
+      'cpu': cpu,
+      'allocatable_cpu': cpu_alloc,
+      'memory': memory,
+      'allocatable_memory': memory_alloc
+      })
+    node_cap_list.sort(key=lambda cap_dict:(cap_dict['allocatable_memory'],
+                                            cap_dict['allocatable_cpu'],
+                                            cap_dict['memory'],
+                                            cap_dict['cpu']))
+    return node_cap_list
     
   def get_imagestreams(self, label=None):
     imagestreams = self.oapi_client.resources.get(kind='ImageStream', api_version='image.openshift.io/v1')

--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -149,7 +149,7 @@ class OpenShift(object):
   # Returns memory in Gi
   def calc_memory(self, memory_str):
     if memory_str[-2:] == 'Ki':
-      memory = float(memory_str[:-2])/1000000 
+      memory = float(memory_str[:-2])/1000000
     elif memory_str[-2:] == 'Mi':
       memory = float(memory_str[:-2])/1000
     elif memory_str[-2:] == 'Gi':
@@ -161,7 +161,7 @@ class OpenShift(object):
     node_list = self.get_nodes()
     for node in node_list.items:
       result += int(node.metadata.labels.get('nvidia.com/gpu.count', 0))
-    return result     
+    return result
 
   def get_node_capacity(self):
     cpu = 0

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -13,6 +13,7 @@ from .images import Images
 from .ui_config import UIConfig
 from .openshift import OpenShift
 from .user import User
+from jupyterhub_singleuser_profiles import sizes
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class SingleuserProfiles(object):
       res = self.merge_profiles(res, p)
 
     if size:
-      s = Sizes(self.sizes)
+      s = Sizes(self.sizes, self.openshift)
       loaded_size = s.get_size(size)
       if loaded_size:
         res = self.merge_profiles(res, loaded_size)
@@ -149,20 +150,24 @@ class SingleuserProfiles(object):
       'segment_key': segment_key,
       'cluster_id': cluster_version.spec.get('clusterID')
     }
+  
+  #def get_size_capacity(self):
+  #  return self.openshift.get_node_capacity()
     
 
   def get_sizes_form(self, username=None):
     if not self.profiles:
       self.load_profiles(username=username)
-    s = Sizes(self.sizes)
+    s = Sizes(self.sizes, self.openshift)
     return s.get_form(self.get_profile_by_name(_USER_CONFIG_PROFILE_NAME).get('last_selected_size'))
 
   def get_size(self, size):
-    s = Sizes(self.sizes)
+    s = Sizes(self.sizes, self.openshift)
     return s.get_size(size)
-    
+
   def get_sizes(self):
-    return self.sizes
+    s = Sizes(self.sizes, self.openshift)
+    return s.sizes
 
   def get_image_info(self, image_name):
     return self.images.get_info(image_name)

--- a/jupyterhub_singleuser_profiles/sizes.py
+++ b/jupyterhub_singleuser_profiles/sizes.py
@@ -5,14 +5,13 @@ from .utils import parse_resources
 
 
 _LOGGER = logging.getLogger(__name__)
-    
+
 class Sizes(object):
     def __init__(self, sizes, openshift):
         self._sizes = sizes
         self.openshift = openshift
 
     def add_label(self):
-
         for size in self._sizes:
             capacity_list = self.openshift.get_node_capacity()
             mem = self.openshift.calc_memory(size['resources']['limits'].get('memory'))
@@ -21,9 +20,6 @@ class Sizes(object):
             for node_cap in capacity_list:
                 if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
                     size['schedulable'] = True #Small enough
-                    break
-                elif mem < node_cap['memory'] and cpu < node_cap['cpu']:
-                    size['schedulable'] = None #Maybe (Warn user)
                     break
                 else:
                     size['schedulable'] = False #Too big (Do not show)
@@ -58,7 +54,7 @@ class Sizes(object):
         else:
             size = None
 
-        return size                        
+        return size
 
     def get_form(self, last_size=None):
         template = """

--- a/jupyterhub_singleuser_profiles/sizes.py
+++ b/jupyterhub_singleuser_profiles/sizes.py
@@ -12,13 +12,14 @@ class Sizes(object):
         self.openshift = openshift
 
     def add_label(self):
+        capacity_buffer = 0.9
         for size in self._sizes:
             capacity_list = self.openshift.get_node_capacity()
-            mem = self.openshift.calc_memory(size['resources']['limits'].get('memory'))
-            cpu = self.openshift.calc_cpu(size['resources']['limits'].get('cpu'))
+            mem = self.openshift.calc_memory(size['resources']['requests'].get('memory'))
+            cpu = self.openshift.calc_cpu(size['resources']['requests'].get('cpu'))
             # Search sorted capacity list from lowest node capacity up
             for node_cap in capacity_list:
-                if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
+                if mem < node_cap['allocatable_memory']*capacity_buffer and cpu < node_cap['allocatable_cpu']*capacity_buffer:
                     size['schedulable'] = True #Small enough
                     break
                 else:

--- a/jupyterhub_singleuser_profiles/sizes.py
+++ b/jupyterhub_singleuser_profiles/sizes.py
@@ -5,10 +5,33 @@ from .utils import parse_resources
 
 
 _LOGGER = logging.getLogger(__name__)
-
+    
 class Sizes(object):
-    def __init__(self, sizes):
-        self.sizes = sizes
+    def __init__(self, sizes, openshift):
+        self._sizes = sizes
+        self.openshift = openshift
+
+    def add_label(self):
+
+        for size in self._sizes:
+            capacity_list = self.openshift.get_node_capacity()
+            mem = self.openshift.calc_memory(size['resources']['limits'].get('memory'))
+            cpu = self.openshift.calc_cpu(size['resources']['limits'].get('cpu'))
+            # Search sorted capacity list from lowest node capacity up
+            for node_cap in capacity_list:
+                if mem < node_cap['allocatable_memory'] and cpu < node_cap['allocatable_cpu']:
+                    size['schedulable'] = True #Small enough
+                    break
+                elif mem < node_cap['memory'] and cpu < node_cap['cpu']:
+                    size['schedulable'] = None #Maybe (Warn user)
+                    break
+                else:
+                    size['schedulable'] = False #Too big (Do not show)
+
+    @property
+    def sizes(self):
+        self.add_label()
+        return self._sizes
 
     def get_size(self, size):
         result = {}
@@ -35,7 +58,7 @@ class Sizes(object):
         else:
             size = None
 
-        return size
+        return size                        
 
     def get_form(self, last_size=None):
         template = """


### PR DESCRIPTION
This PR adds a flag to the sizes returned by the API. It queries OpenShift nodes and checks the sizes agains nodes allocatable capacity.

If the size is over all the nodes allocatable resources, it will be flaged as `schedulable: false`, so that the UI can decide what to do about it.