### PR TITLE
Add an error message if the configmap has incorrect type.

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -62,6 +62,13 @@ class SingleuserProfiles(object):
       for cm_name in profiles_config_maps:
         config_map_yaml = self.openshift.read_config_map(cm_name, key_name)
         if config_map_yaml:
+          if type(config_map_yaml) != dict:
+            message = '''
+            ConfigMap %s is incorrect - content must be object, not list.
+            Please review configuration documentation for the 
+            jupyterhub-singleuser-profiles library.
+            '''%cm_name
+            raise TypeError(message)
           self.gpu_types.extend(config_map_yaml.get("gpuTypes", []))
           self.sizes.extend(config_map_yaml.get("sizes", []))
           self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))


### PR DESCRIPTION
Thiis PR adds the foolowing error message if any of the configmaps loaded in the load_profiels funciton is of incorrect type (commonly caused by mistakes in the yaml structure):

```
Ignoring CM <name> - content must be object, not list.
Please review configuration documentation for the 
jupyterhub-singleuser-profiles library.
```