### PR TITLE
api.py: Add check for initialized authenticated user object before calling "user.get"

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -49,10 +49,11 @@ def authenticated(f):
                 user = auth.user_for_token(token, use_cache=False)
         else:
             user = None
-        if for_user and user.get('admin'):
-            user['name'] = for_user
-            user['admin'] = False
+
         if user:
+            if for_user and user.get('admin'):
+                user['name'] = for_user
+                user['admin'] = False
             return f(user=user, *args, **kwargs)
         else:
             # redirect to login url on failed auth


### PR DESCRIPTION
PR adds a check initialization of the `user` object before attempting to call `user.get`.  This fixes a scenario where `authenticated` decorator would throw an exception when `user is None` and `user.get()` is called

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>