### PR TITLE
Watch available images, don't enable Start until one is selected

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/package-lock.json
+++ b/jupyterhub_singleuser_profiles/ui/package-lock.json
@@ -18,6 +18,7 @@
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
         "dompurify": "^2.2.6",
+        "lodash-es": "^4.17.15",
         "node-gyp": "^7.1.2",
         "node-sass": "^4.14.1",
         "react": "^16.13.1",
@@ -10780,6 +10781,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -30508,6 +30514,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/jupyterhub_singleuser_profiles/ui/package.json
+++ b/jupyterhub_singleuser_profiles/ui/package.json
@@ -44,6 +44,7 @@
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",
     "dompurify": "^2.2.6",
+    "lodash-es": "^4.17.15",
     "node-gyp": "^7.1.2",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",

--- a/jupyterhub_singleuser_profiles/ui/src/App/App.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/App/App.tsx
@@ -13,16 +13,25 @@ import ImageForm from '../ImageForm/ImageForm';
 import SizesForm from '../SizesForm/SizesForm';
 import EnvVarForm from '../EnvVarForm/EnvVarForm';
 import { APIGet } from '../utils/APICalls';
-import { UI_CONFIG_PATH } from '../utils/const';
-import { UiConfigType } from '../utils/types';
+import { CM_PATH, UI_CONFIG_PATH } from '../utils/const';
+import { UiConfigType, UserConfigMapType } from '../utils/types';
 
 import './App.scss';
 
 const App: React.FC = () => {
   const [uiConfig, setUiConfig] = React.useState<UiConfigType>();
   const [configError, setConfigError] = React.useState<string>();
+  const [imageValid, setImageValid] = React.useState<boolean>(false);
+  const [userConfig, setUserConfig] = React.useState<UserConfigMapType>();
+
   React.useEffect(() => {
     let cancelled = false;
+
+    APIGet(CM_PATH).then((data: UserConfigMapType) => {
+      if (!cancelled) {
+        setUserConfig(data);
+      }
+    });
 
     APIGet(UI_CONFIG_PATH)
       .then((data: UiConfigType) => {
@@ -53,7 +62,7 @@ const App: React.FC = () => {
       );
     }
 
-    if (!uiConfig) {
+    if (!uiConfig || !userConfig) {
       return (
         <EmptyState variant={EmptyStateVariant.full}>
           <Spinner isSVG size="xl" />
@@ -63,12 +72,19 @@ const App: React.FC = () => {
 
     return (
       <>
-        <ImageForm uiConfig={uiConfig} />
-        <SizesForm uiConfig={uiConfig} />
-        {uiConfig.envVarConfig?.enabled !== false && <EnvVarForm uiConfig={uiConfig} />}
+        <ImageForm
+          uiConfig={uiConfig}
+          userConfig={userConfig}
+          onValidImage={() => setImageValid(true)}
+        />
+        <SizesForm uiConfig={uiConfig} userConfig={userConfig} />
+        {uiConfig.envVarConfig?.enabled !== false && (
+          <EnvVarForm uiConfig={uiConfig} userConfig={userConfig} />
+        )}
         <div className="jsp-spawner__buttons-bar">
           <input
             type="submit"
+            disabled={!imageValid}
             value="Start server"
             className="jsp-spawner__submit-button pf-c-button pf-m-primary"
           />

--- a/jupyterhub_singleuser_profiles/ui/src/EnvVarForm/EnvVarForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/EnvVarForm/EnvVarForm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonVariant, Form } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { APIGet, APIPost } from '../utils/APICalls';
+import { APIPost } from '../utils/APICalls';
 import { CM_PATH } from '../utils/const';
 import { UserConfigMapType, EnvVarType, UiConfigType } from '../utils/types';
 import { CUSTOM_VARIABLE, EMPTY_KEY, VariableRow } from './types';
@@ -11,30 +11,23 @@ import './EnvVarForm.scss';
 
 type ImageFormProps = {
   uiConfig: UiConfigType;
+  userConfig: UserConfigMapType;
 };
 
-const EnvVarForm: React.FC<ImageFormProps> = ({ uiConfig }) => {
+const EnvVarForm: React.FC<ImageFormProps> = ({ uiConfig, userConfig }) => {
   const [variableRows, setVariableRows] = React.useState<VariableRow[]>([]);
   const [savedEnvJson, setSavedEnvJson] = React.useState<string>('');
 
   React.useEffect(() => {
-    let cancelled = false;
-    APIGet(CM_PATH).then((data: UserConfigMapType) => {
-      if (!cancelled) {
-        const env = data.env;
-        const rows: VariableRow[] = env.map((variable) => ({
-          variableType: CUSTOM_VARIABLE,
-          variables: [variable],
-          errors: {},
-        }));
-        setVariableRows(rows);
-        setSavedEnvJson(JSON.stringify({ env }));
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    const env = userConfig.env || [];
+    const rows: VariableRow[] = env.map((variable) => ({
+      variableType: CUSTOM_VARIABLE,
+      variables: [variable],
+      errors: {},
+    }));
+    setVariableRows(rows);
+    setSavedEnvJson(JSON.stringify({ env }));
+  }, [userConfig]);
 
   const postEnvChange = (updatedRows: VariableRow[]) => {
     const env = updatedRows.reduce((acc, row) => {

--- a/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/__mock__/mockData.ts
@@ -24,7 +24,7 @@ export const mockData: MockDataType = {
     env: [],
     gpu: 0,
     last_selected_image: 's2i-generic-data-science-notebook:v0.0.24',
-    last_selected_size: 'Default',
+    last_selected_size: 'Large',
   },
   [DEFAULT_IMAGE_PATH]: 's2i-generic-data-science-notebook:v0.0.4',
   [SIZES_PATH]: ['Small', 'Medium', 'Large', 'Huge'],
@@ -419,6 +419,7 @@ export const mockData: MockDataType = {
         memory: '4Gi',
       },
     },
+    schedulable: false,
   },
   ['size/Huge']: {
     name: 'Huge',

--- a/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { API_BASE_PATH, DEV_MODE, DEV_SERVER, MOCK_MODE } from './const';
 import { mockData } from '../__mock__/mockData';
 
@@ -29,7 +30,7 @@ export const APIGet = (target: string): Promise<any> => {
   }
 
   if (MOCK_MODE) {
-    return Promise.resolve(mockData[target]);
+    return Promise.resolve(_.cloneDeep(mockData[target]));
   }
 
   return new Promise((resolve, reject) => {
@@ -39,7 +40,7 @@ export const APIGet = (target: string): Promise<any> => {
         if (response.ok) {
           resolve(response.json());
         } else {
-          reject('Failed to fetch ' + target + response);
+          reject(`Failed to fetch ${target}: ${response.statusText}`);
         }
       })
       .catch((err) => {
@@ -69,7 +70,7 @@ export const APIPost = (target: string, json: string): Promise<void> => {
         if (response.ok) {
           resolve();
         } else {
-          reject('Failed to send ' + target);
+          reject(`Failed to send ${target}: ${response.statusText}`);
         }
       })
       .catch((err) => {

--- a/jupyterhub_singleuser_profiles/ui/src/utils/const.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/const.ts
@@ -2,6 +2,9 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 export const DEV_SERVER = process.env.DEV_SERVER || '';
 export const MOCK_MODE = process.env.MOCK_MODE === 'true';
 export const ABOUT_NOTEBOOK_IMAGES_LINK = process.env.ABOUT_NOTEBOOK_IMAGES_LINK || '';
+export const POLL_INTERVAL = process.env.POLL_INTERVAL
+  ? parseInt(process.env.POLL_INTERVAL)
+  : 30000;
 
 export const API_BASE_PATH = '/services/jsp-api/api/';
 export const CM_PATH = 'user/configmap';

--- a/jupyterhub_singleuser_profiles/ui/src/utils/useWatchImages.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/useWatchImages.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { IMAGE_PATH, POLL_INTERVAL } from './const';
+import { ImageType } from './types';
+import { APIGet } from './APICalls';
+
+export const useWatchImages = (): ImageType[] => {
+  const [images, setImages] = React.useState<ImageType[]>([]);
+  const prevResults = React.useRef<ImageType[]>();
+
+  React.useEffect(() => {
+    let watchHandle;
+    const fetchImages = () => {
+      APIGet(IMAGE_PATH)
+        .then((data: ImageType[]) => {
+          if (!_.isEqual(data, prevResults.current)) {
+            setImages(data);
+            prevResults.current = data;
+          }
+        })
+        .catch(() => {
+          // ignore
+        });
+      watchHandle = setTimeout(fetchImages, POLL_INTERVAL);
+    };
+    fetchImages();
+
+    return () => {
+      if (watchHandle) {
+        clearTimeout(watchHandle);
+      }
+    };
+  }, []);
+
+  return images;
+};


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/RHODS-1920

**Analysis / Root cause**: 
The selectable images do not update as images become available upon build completion. If a previously selected size is no longer valid it is still used unless the user changes the selection

**Solution Description**: 
Add a hook to watch the image lists and update when there are changes.
Update the Size form to not use a previous selected size if that size is no longer valid.
Reduce the number of times the user config map is retrieved (retrieve once instead of in each form).

