### PR TITLE
Fix to save settings and spawn servers for other users correctly

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/App/App.scss
+++ b/jupyterhub_singleuser_profiles/ui/src/App/App.scss
@@ -3,6 +3,11 @@
 
   &__header {
     color: var(--pf-global--Color--100);
+    max-width: 768px;
+
+    .pf-c-alert {
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
 
     &__title {
       font-size: var(--pf-global--FontSize--2xl);

--- a/jupyterhub_singleuser_profiles/ui/src/App/App.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/App/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import '@patternfly/patternfly/patternfly.min.css';
+import '@patternfly/patternfly/patternfly-addons.css';
 import {
+  Alert,
   Title,
   EmptyState,
   EmptyStateVariant,
@@ -13,7 +15,7 @@ import ImageForm from '../ImageForm/ImageForm';
 import SizesForm from '../SizesForm/SizesForm';
 import EnvVarForm from '../EnvVarForm/EnvVarForm';
 import { APIGet } from '../utils/APICalls';
-import { CM_PATH, UI_CONFIG_PATH } from '../utils/const';
+import { CM_PATH, FOR_USER, UI_CONFIG_PATH } from '../utils/const';
 import { UiConfigType, UserConfigMapType } from '../utils/types';
 
 import './App.scss';
@@ -96,6 +98,13 @@ const App: React.FC = () => {
   return (
     <div className="jsp-spawner">
       <div className="jsp-spawner__header">
+        {FOR_USER ? (
+          <Alert
+            isInline
+            variant="info"
+            title={`This notebook server is being created for ${FOR_USER}`}
+          />
+        ) : null}
         <div className="jsp-spawner__header__title">Start a notebook server</div>
         <div className="jsp-spawner__header__sub-title">
           Select options for your notebook server.

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
@@ -60,6 +60,7 @@ const ImageForm: React.FC<ImageFormProps> = ({ userConfig, onValidImage }) => {
     const currentTag = currentImage?.tags?.find((tag) => tag.name === prevSelectedImageTag?.tag);
     if (currentImage && currentTag) {
       setSelectedImageTag(prevSelectedImageTag);
+      postChange(userConfig.last_selected_image);
       onValidImage && onValidImage();
       return;
     }

--- a/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/APICalls.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { API_BASE_PATH, DEV_MODE, DEV_SERVER, MOCK_MODE } from './const';
+import { API_BASE_PATH, DEV_MODE, DEV_SERVER, MOCK_MODE, FOR_USER } from './const';
 import { mockData } from '../__mock__/mockData';
 
 const getRequestPath = (target: string) => {
@@ -9,24 +9,11 @@ const getRequestPath = (target: string) => {
   return API_BASE_PATH + target;
 };
 
-const getForUser = () => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const jhdata = window.jhdata;
-
-  if (jhdata?.['user']) {
-    return jhdata['user'];
-  }
-  return null;
-};
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const APIGet = (target: string): Promise<any> => {
-  const targetUser = getForUser();
   const headers = {};
-  if (targetUser) {
-    headers['For-User'] = targetUser;
+  if (FOR_USER) {
+    headers['For-User'] = FOR_USER;
   }
 
   if (MOCK_MODE) {
@@ -52,12 +39,11 @@ export const APIGet = (target: string): Promise<any> => {
 };
 
 export const APIPost = (target: string, json: string): Promise<void> => {
-  const targetUser = getForUser();
   const headers = {
     'Content-Type': 'application/json',
   };
-  if (targetUser) {
-    headers['For-User'] = targetUser;
+  if (FOR_USER) {
+    headers['For-User'] = FOR_USER;
   }
 
   if (MOCK_MODE) {

--- a/jupyterhub_singleuser_profiles/ui/src/utils/const.ts
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/const.ts
@@ -13,3 +13,9 @@ export const IMAGE_PATH = 'images';
 export const DEFAULT_IMAGE_PATH = 'images/default';
 export const UI_CONFIG_PATH = 'ui/config';
 export const SINGLE_SIZE_PATH = 'size';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const jhData = window.jhdata as { user: string; for_user: string };
+export const USER = DEV_MODE ? 'DevUser' : jhData?.user ?? '';
+export const FOR_USER = DEV_MODE ? process.env.FOR_USER || '' : jhData?.for_user ?? '';

--- a/jupyterhub_singleuser_profiles/ui/src/utils/useWatchImages.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/utils/useWatchImages.tsx
@@ -4,8 +4,8 @@ import { IMAGE_PATH, POLL_INTERVAL } from './const';
 import { ImageType } from './types';
 import { APIGet } from './APICalls';
 
-export const useWatchImages = (): ImageType[] => {
-  const [images, setImages] = React.useState<ImageType[]>([]);
+export const useWatchImages = (): ImageType[] | undefined => {
+  const [images, setImages] = React.useState<ImageType[]>();
   const prevResults = React.useRef<ImageType[]>();
 
   React.useEffect(() => {

--- a/jupyterhub_singleuser_profiles/ui/templates/spawn.html
+++ b/jupyterhub_singleuser_profiles/ui/templates/spawn.html
@@ -16,9 +16,6 @@
 </script>
 {% endif -%}
 <div>
-  {% if for_user and user.name != for_user.name -%}
-    <p>Spawning server for {{ for_user.name }}</p>
-  {% endif -%}
   {% if error_message -%}
     <p class="spawn-error-msg text-danger">
       Error: {{error_message}}


### PR DESCRIPTION
**Fixes**: 
Jira: https://issues.redhat.com/browse/ODH-503

**Analysis / Root cause**: 
The window parameter for jhData.for_user was not being used as the user being sent as for_user back to the API.

**Solution Description**: 
Update the display to add an inline alert for the user the notebook is being created for rather than simple html text.
Set the `FOR_USER` constant if the `jhData.for_user` value is set and pass that along to the API when retrieving/updating the user config.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/136842770-db597aa3-db7b-4f7a-905c-bd87574c0c20.png)

/cc @dlabaj