### PR TITLE
Add a case for when node memory allocatable is in bytes

### DIFF
--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -154,6 +154,9 @@ class OpenShift(object):
       memory = float(memory_str[:-2])/1000
     elif memory_str[-2:] == 'Gi':
       memory = float(memory_str[:-2])
+    else:
+      # Memory unit is bytes
+      memory = float(memory_str)/1000000000
     return memory
 
   def get_gpu_number(self):


### PR DESCRIPTION
In some cases we have seen where a node can report its allocatable
memory amount in bytes, with no unit specifier at the end. JSP does not
currenty support this case. When this happens, no notebook size options
are presented to the user and there is no ability to spawn a notebook.
This adds a case to the function to handle this.