### PR TITLE
Add millibyte check to node checking

### DIFF
--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -154,6 +154,8 @@ class OpenShift(object):
       memory = float(memory_str[:-2])/1000
     elif memory_str[-2:] == 'Gi':
       memory = float(memory_str[:-2])
+    elif memory_str[-1:] == 'm':
+      memory = float(memory_str[:-1])/1000000000000
     else:
       # Memory unit is bytes
       memory = float(memory_str)/1000000000


### PR DESCRIPTION
This PR adds a check for the kubernetes suffix 'm' which can sometimes appear beside memory values.

Jira link: