### PR TITLE
Limit jupyterhub version under 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pydantic
 jinja2
 escapism
 tornado
-jupyterhub
+jupyterhub < 2.0.0


### PR DESCRIPTION
Necessary to prevent new errors (like changes to HubAuth)